### PR TITLE
Improve social sharing metadata: title, description, and absolute OG/Twitter image URLs

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -15,11 +15,37 @@
         <link rel="manifest" href="%sveltekit.assets%/site.webmanifest" />
 
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta property="og:image" content="%sveltekit.assets%/other-images/share-thumb.png" />
-        <meta property="og:image:alt" content="GE Skiller share thumbnail" />
+        <title>GE Skiller: Find the Best OSRS Items to Craft & Profit</title>
+        <meta
+            name="description"
+            content="Find the best things to make using your skill levels, powered by real-time GE prices on GE Skiller."
+        />
+
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="GE Skiller" />
+        <meta property="og:title" content="GE Skiller: Find the Best OSRS Items to Craft & Profit" />
+        <meta
+            property="og:description"
+            content="Find the best things to make using your skill levels, powered by real-time GE prices on GE Skiller."
+        />
+        <meta property="og:url" content="https://ge-skiller.netlify.app/" />
+        <meta property="og:image" content="https://ge-skiller.netlify.app/other-images/share-thumb.png" />
+        <meta
+            property="og:image:alt"
+            content="GE Skiller. Find the best things to make using your skill levels. Powered by real-time GE prices."
+        />
+
         <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:image" content="%sveltekit.assets%/other-images/share-thumb.png" />
-        <meta name="twitter:image:alt" content="GE Skiller share thumbnail" />
+        <meta name="twitter:title" content="GE Skiller: Find the Best OSRS Items to Craft & Profit" />
+        <meta
+            name="twitter:description"
+            content="Find the best things to make using your skill levels, powered by real-time GE prices on GE Skiller."
+        />
+        <meta name="twitter:image" content="https://ge-skiller.netlify.app/other-images/share-thumb.png" />
+        <meta
+            name="twitter:image:alt"
+            content="GE Skiller. Find the best things to make using your skill levels. Powered by real-time GE prices."
+        />
         %sveltekit.head%
     </head>
     <body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
### Motivation
- Social preview crawlers reported a missing description and an overly short title, and some crawlers fail to resolve the relative thumbnail URL, so the homepage share preview does not render correctly.

### Description
- Updated `src/app.html` to add a descriptive page `title` and a standard `description` meta tag. 
- Added Open Graph tags `og:type`, `og:site_name`, `og:title`, `og:description`, and `og:url` to improve link previews. 
- Switched `og:image` and `twitter:image` to absolute URLs and updated image alt text, and added aligned `twitter:title` and `twitter:description` so social platforms can resolve the thumbnail reliably. 

### Testing
- Ran `npm run check` which failed due to pre-existing TypeScript/Svelte diagnostics unrelated to `src/app.html`, so the metadata change itself was not responsible for the failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ff7ab419c832dbe20fb29dcfa1da0)