### PR TITLE
Speed up character-specific item queries and ingredient tree population

### DIFF
--- a/src/lib/models/mongo-schemas/osrsbox-db-item-schema.ts
+++ b/src/lib/models/mongo-schemas/osrsbox-db-item-schema.ts
@@ -120,5 +120,10 @@ export const osrsboxItemSchema: Schema<OsrsboxItemDocument> = new Schema(
     { collection: 'items' },
 );
 
+// Covers the browse-page base filter and its highPrice sort so listing queries
+// don't collection-scan; the name index serves prefix-anchored search regexes.
+osrsboxItemSchema.index({ tradeable_on_ge: 1, placeholder: 1, noted: 1, stacked: 1, highPrice: -1 });
+osrsboxItemSchema.index({ name: 1 });
+
 export const OsrsboxItemModel: Model<OsrsboxItemDocument> =
     mongoose.models.OsrsboxItem || mongoose.model<OsrsboxItemDocument>('OsrsboxItem', osrsboxItemSchema);

--- a/src/lib/services/game-item-mongo-service.server.ts
+++ b/src/lib/services/game-item-mongo-service.server.ts
@@ -44,11 +44,79 @@ export async function populateIngredientsTree(itemId: string): Promise<IOsrsboxI
         .exec();
     if (!root) return null;
 
-    // Cache results so we don't refetch the same ingredient multiple times
+    // Fetch each unique ingredient exactly once, batching one query per tree level
+    // instead of issuing a round-trip per ingredient document.
     const cache = new Map<string, IOsrsboxItemWithMeta>();
-    await populateIngredientsRecursive(root, cache, 0);
+    let frontier = collectIngredientIds(root);
+    for (let depth = 0; depth < MAX_INGREDIENT_DEPTH && frontier.length; depth += 1) {
+        const missing = Array.from(new Set(frontier)).filter((id) => !cache.has(id));
+        if (!missing.length) break;
+
+        const docs = await OsrsboxItemModel.find({ _id: { $in: missing.map((id) => new Types.ObjectId(id)) } })
+            .lean<(IOsrsboxItemWithMeta & { _id: Types.ObjectId })[]>()
+            .exec();
+
+        frontier = [];
+        for (const doc of docs) {
+            cache.set(doc._id.toString(), doc);
+            frontier.push(...collectIngredientIds(doc));
+        }
+    }
+
+    attachIngredientsFromCache(root, root, cache, 0);
 
     return root;
+}
+
+/**
+ * Returns the ObjectId keys of all ingredient references on an unpopulated (raw) item document.
+ */
+function collectIngredientIds(item: IOsrsboxItemWithMeta): string[] {
+    const ids: string[] = [];
+    for (const spec of item.creationSpecs ?? []) {
+        for (const ingredient of spec.ingredients ?? []) {
+            const raw = ingredient.item as unknown;
+            if (raw instanceof Types.ObjectId) ids.push(raw.toString());
+        }
+    }
+    return ids;
+}
+
+/**
+ * Replaces ingredient ObjectId references with materialized copies of the cached documents.
+ * Walks the raw `source` doc for ingredient ids (structuredClone strips the ObjectId prototype
+ * from `target`) and gives every occurrence its own clone so the tree has no shared object
+ * graphs, which JSON.stringify would otherwise duplicate or treat as circular. The depth
+ * budget also bounds cyclic ingredient data.
+ */
+function attachIngredientsFromCache(
+    target: IOsrsboxItemWithMeta,
+    source: IOsrsboxItemWithMeta,
+    cache: Map<string, IOsrsboxItemWithMeta>,
+    depth: number,
+): void {
+    if (depth >= MAX_INGREDIENT_DEPTH) return;
+
+    const targetSpecs = target.creationSpecs ?? [];
+    const sourceSpecs = source.creationSpecs ?? [];
+
+    for (let specIndex = 0; specIndex < sourceSpecs.length; specIndex += 1) {
+        const sourceIngredients = sourceSpecs[specIndex]?.ingredients ?? [];
+        const targetIngredients = targetSpecs[specIndex]?.ingredients ?? [];
+
+        for (let i = 0; i < sourceIngredients.length; i += 1) {
+            const raw = sourceIngredients[i]?.item as unknown;
+            const targetIngredient = targetIngredients[i];
+            if (!(raw instanceof Types.ObjectId) || !targetIngredient) continue;
+
+            const cached = cache.get(raw.toString());
+            if (!cached) continue;
+
+            const copy = structuredClone(cached);
+            targetIngredient.item = copy as unknown as (typeof targetIngredient)['item'];
+            attachIngredientsFromCache(copy, cached, cache, depth + 1);
+        }
+    }
 }
 
 /**
@@ -156,6 +224,10 @@ export async function getPaginatedGameItems(params?: {
         ? buildProfitPipeline(supplyMap, profitSort, profitSort && suppliesFilterActive)
         : [];
     const supplyStages = !profitSort && suppliesFilterActive ? buildSuppliesFilterPipeline(supplyMap) : [];
+    // Profit only needs to be computed for every candidate when it drives the sort order;
+    // otherwise it can wait until after pagination and run for just the returned page.
+    const profitStagesBeforeSort = profitSort ? profitStages : [];
+    const profitStagesAfterPagination = profitSort ? [] : profitStages;
     const sortStage = profitSort
         ? { creationProfit: sortDirection, highPrice: -1, cost: -1, name: 1 }
         : { highPrice: sortDirection, cost: sortDirection, name: 1 };
@@ -166,12 +238,14 @@ export async function getPaginatedGameItems(params?: {
     }>([
         { $match: filterQuery },
         ...(skillLevels ? [{ $match: { $expr: buildPlayerSkillMatchExpression(skillLevels) } }] : []),
+        // Drop heavy fields the browse page never renders before docs hit the blocking $sort.
+        { $unset: ['equipment', 'weapon'] },
         ...supplyStages,
-        ...profitStages,
+        ...profitStagesBeforeSort,
         { $sort: sortStage },
         {
             $facet: {
-                items: [{ $skip: skip }, { $limit: perPage }],
+                items: [{ $skip: skip }, { $limit: perPage }, ...profitStagesAfterPagination],
                 totalDocs: [{ $count: 'count' }],
             },
         },
@@ -417,17 +491,20 @@ function buildProfitPipeline(
             },
         },
         {
+            $set: {
+                consumedIngredientIds: {
+                    $map: { input: '$consumedIngredients', as: 'ing', in: '$$ing.item' },
+                },
+            },
+        },
+        {
+            // localField/foreignField joins use the _id index; an $expr $in match cannot,
+            // which made this lookup a full collection scan per candidate document.
             $lookup: {
                 from: 'items',
-                let: {
-                    ingredientIds: {
-                        $map: { input: '$consumedIngredients', as: 'ing', in: '$$ing.item' },
-                    },
-                },
-                pipeline: [
-                    { $match: { $expr: { $in: ['$_id', '$$ingredientIds'] } } },
-                    { $project: { _id: 1, id: 1, highPrice: 1, lowPrice: 1, cost: 1 } },
-                ],
+                localField: 'consumedIngredientIds',
+                foreignField: '_id',
+                pipeline: [{ $project: { _id: 1, id: 1, highPrice: 1, lowPrice: 1, cost: 1 } }],
                 as: 'ingredientItems',
             },
         },
@@ -470,6 +547,7 @@ function buildProfitPipeline(
         $unset: [
             'primarySpec',
             'consumedIngredients',
+            'consumedIngredientIds',
             'ingredientItems',
             'ingredientCostRows',
             'costKnown',
@@ -534,17 +612,20 @@ function buildSuppliesFilterPipeline(supplies?: PlayerSupplies | null): Record<s
         { $set: { requiredIngredients: { $ifNull: ['$primarySpec.ingredients', []] } } },
         { $match: { $expr: { $gt: [{ $size: '$requiredIngredients' }, 0] } } },
         {
+            $set: {
+                requiredIngredientIds: {
+                    $map: { input: '$requiredIngredients', as: 'ing', in: '$$ing.item' },
+                },
+            },
+        },
+        {
+            // localField/foreignField joins use the _id index; an $expr $in match cannot,
+            // which made this lookup a full collection scan per candidate document.
             $lookup: {
                 from: 'items',
-                let: {
-                    ingredientIds: {
-                        $map: { input: '$requiredIngredients', as: 'ing', in: '$$ing.item' },
-                    },
-                },
-                pipeline: [
-                    { $match: { $expr: { $in: ['$_id', '$$ingredientIds'] } } },
-                    { $project: { _id: 1, id: 1 } },
-                ],
+                localField: 'requiredIngredientIds',
+                foreignField: '_id',
+                pipeline: [{ $project: { _id: 1, id: 1 } }],
                 as: 'ingredientItems',
             },
         },
@@ -563,7 +644,16 @@ function buildSuppliesFilterPipeline(supplies?: PlayerSupplies | null): Record<s
             },
         },
         { $match: { suppliesSatisfied: true } },
-        { $unset: ['primarySpec', 'requiredIngredients', 'ingredientItems', 'supplyRows', 'suppliesSatisfied'] },
+        {
+            $unset: [
+                'primarySpec',
+                'requiredIngredients',
+                'requiredIngredientIds',
+                'ingredientItems',
+                'supplyRows',
+                'suppliesSatisfied',
+            ],
+        },
     ];
 }
 
@@ -757,44 +847,4 @@ function buildPlayerSkillMatchExpression(skillLevels: PlayerSkillLevels) {
             0,
         ],
     };
-}
-
-async function populateIngredientsRecursive(
-    item: IOsrsboxItemWithMeta & { _id?: Types.ObjectId },
-    cache: Map<string, IOsrsboxItemWithMeta>,
-    depth: number,
-): Promise<void> {
-    if (depth >= MAX_INGREDIENT_DEPTH) return;
-    const specs = Array.isArray(item.creationSpecs) ? item.creationSpecs : [];
-    if (!specs.length) return;
-
-    await Promise.all(
-        specs.map(async (spec) => {
-            if (!spec.ingredients?.length) return;
-
-            await Promise.all(
-                spec.ingredients.map(async (ingredient) => {
-                    const ingredientId = ingredient.item as unknown as Types.ObjectId | undefined;
-                    if (!ingredientId) return;
-
-                    const key = ingredientId.toString();
-                    if (!cache.has(key)) {
-                        const populated = await OsrsboxItemModel.findById(ingredientId)
-                            .lean<IOsrsboxItemWithMeta & { _id: Types.ObjectId }>()
-                            .exec();
-                        if (!populated) return;
-
-                        cache.set(key, populated);
-                        await populateIngredientsRecursive(populated, cache, depth + 1);
-                    }
-
-                    const cached = cache.get(key);
-                    if (cached) {
-                        // Clone to prevent shared object graphs that JSON.stringify treats as circular.
-                        ingredient.item = structuredClone(cached);
-                    }
-                }),
-            );
-        }),
-    );
 }


### PR DESCRIPTION
## Problem

The character-specific item queries (filter by my skill levels / supplies / profit) could take 20–60 seconds — long enough that the UI ships a "Longer wait time" warning dialog. Profiling the query path in `getPaginatedGameItems` surfaced four compounding issues, plus an N+1 pattern in the ingredient-tree endpoint.

## Root cause

The dominant cost was the ingredient `$lookup`s in the profit and supplies pipelines. They matched with `$expr: { $in: ['$_id', '$$ingredientIds'] }`, and MongoDB **cannot use the `_id` index for `$expr` `$in` matches** — so every candidate item triggered a full scan of the (heavy, base64-icon-laden) `items` collection. Thousands of candidates × a full collection scan each = tens of seconds.

## Changes

- **Indexed lookups** — both ingredient `$lookup`s now use the `localField`/`foreignField` form (with a `$project` sub-pipeline), which uses the `_id` index. This is the headline fix.
- **Profit computed per page, not per collection** — when profit is displayed but not the sort key, the profit stages now run inside the `$facet` items sub-pipeline *after* `$skip`/`$limit`, so only the 12–192 returned items pay for the lookup instead of every matching item. When sorting by profit it still runs before the sort (required for correctness).
- **Lighter sort input** — `equipment`/`weapon` blobs (never rendered by the browse page) are dropped before the blocking `$sort`, reducing in-memory sort size and disk spill.
- **Indexes** — added a compound index covering the browse-page base filter + `highPrice` sort, and a `name` index for the prefix-anchored search regexes. Mongoose builds these automatically on startup (`autoIndex`); first boot after deploy will build them in the background.
- **Batched ingredient-tree population** — `populateIngredientsTree` previously issued one `findById` per unique ingredient, recursively. It now does a breadth-first fetch with one `$in` query per tree level (≤ 12 queries total), then links the tree in a deterministic pass. This also fixes a race where concurrent branches could `structuredClone` a partially-populated cached subtree.

No API shapes change other than the browse list no longer including the unused `equipment`/`weapon` fields.

Note: the `localField`/`foreignField` + `pipeline` lookup form requires MongoDB ≥ 5.0 (all current Atlas tiers qualify).

## Verification

- `eslint` passes on both touched files.
- `svelte-check` reports the same pre-existing errors as `main` (34 baseline errors, none introduced; the aggregate-call type complaint existed before at the old line number).
- Could not run against the live Atlas cluster from this environment (no DB credentials), so please demo the skill/supplies/profit toggles against real data before merging.

## Further ideas (not in this PR)

- **Precompute `creationCost`/`creationProfit`** at price-refresh time (in `run-update-item-prices.ts`). Without supplies, profit is character-independent, so profit sort would become a plain indexed sort with zero runtime lookups.
- **Flatten `treeMinSkills` into an indexable array** (e.g. `[{ skill, level }]`) so the skill-level filter can use `$elemMatch` queries against indexes instead of the large per-document `$expr`.
- Sort on a minimal projection and re-hydrate only the returned page via a self-`$lookup` if sort spill is still visible on the Atlas tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWzx1r7ScTb6qa3AcqTQhE

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWzx1r7ScTb6qa3AcqTQhE)_