### PR TITLE
Remove long-wait warning dialog and fix save toast wording

### DIFF
--- a/src/lib/components/dialogs/character-stats-dialog.svelte
+++ b/src/lib/components/dialogs/character-stats-dialog.svelte
@@ -51,10 +51,14 @@
     function resetDialog() {
         populatedStats.set(new CharacterProfile(''));
         isLoading.set(false);
+        wasImported.set(false);
     }
 
     // Denotes whether we're in the process of loading/importing character data.
     const isLoading = writable(false);
+
+    // Denotes whether the current populated stats came from an import, for toast wording on save.
+    const wasImported = writable(false);
 
     const characterStore = $derived(getStoreRoot());
     const characters = $derived(getCharacters());
@@ -92,7 +96,11 @@
 
         // Set this character as active, show a toast to the user, and notify parent component of selection.
         characterStore.activeCharacter = buffer.id;
-        toast.success(`Character "${buffer.name}" has been created.`);
+        toast.success(
+            get(wasImported)
+                ? `Character "${buffer.name}" has been imported and saved.`
+                : `Character "${buffer.name}" has been saved.`,
+        );
         onCharacterSelected();
 
         // Close the dialog.
@@ -108,6 +116,7 @@
         try {
             const character = await fetchCharacterDetailsFromWOM($populatedStats.name);
             populatedStats.set(cloneProfile(character));
+            wasImported.set(true);
         } catch (e) {
             toast.error(`Failed to import character "${$populatedStats.name}". Please check the name and try again.`);
             console.error(e);

--- a/src/lib/components/dialogs/character-stats-dialog.svelte
+++ b/src/lib/components/dialogs/character-stats-dialog.svelte
@@ -51,14 +51,15 @@
     function resetDialog() {
         populatedStats.set(new CharacterProfile(''));
         isLoading.set(false);
-        wasImported.set(false);
+        importedName.set(null);
     }
 
     // Denotes whether we're in the process of loading/importing character data.
     const isLoading = writable(false);
 
-    // Denotes whether the current populated stats came from an import, for toast wording on save.
-    const wasImported = writable(false);
+    // Name of the character last successfully imported, for toast wording on save. Cleared (or left stale but
+    // unmatched) if the name is changed afterward, so the save toast only claims "imported" when it's still true.
+    const importedName = writable<string | null>(null);
 
     const characterStore = $derived(getStoreRoot());
     const characters = $derived(getCharacters());
@@ -97,7 +98,7 @@
         // Set this character as active, show a toast to the user, and notify parent component of selection.
         characterStore.activeCharacter = buffer.id;
         toast.success(
-            get(wasImported)
+            get(importedName) === buffer.name
                 ? `Character "${buffer.name}" has been imported and saved.`
                 : `Character "${buffer.name}" has been saved.`,
         );
@@ -116,7 +117,7 @@
         try {
             const character = await fetchCharacterDetailsFromWOM($populatedStats.name);
             populatedStats.set(cloneProfile(character));
-            wasImported.set(true);
+            importedName.set(character.name);
         } catch (e) {
             toast.error(`Failed to import character "${$populatedStats.name}". Please check the name and try again.`);
             console.error(e);

--- a/src/lib/components/items/game-items-page.svelte
+++ b/src/lib/components/items/game-items-page.svelte
@@ -4,7 +4,6 @@
     import * as Select from '$lib/components/ui/select';
     import { Label } from '$lib/components/ui/label';
     import { Switch } from '$lib/components/ui/switch';
-    import * as AlertDialog from '$lib/components/ui/alert-dialog';
     import { onDestroy } from 'svelte';
     import { defaultSkillLevels } from '$lib/constants/default-skill-levels';
     import type { SkillTreePage } from '$lib/constants/skill-tree-pages';
@@ -121,13 +120,8 @@
     let lastSkillSlug: string | null = null;
     const isMobile = $derived(typeof window !== 'undefined' && window.matchMedia('(max-width: 767px)').matches);
     const cacheSkipKey = 'ge-skiller:items-cache:skip';
-    const longWaitSkipKey = 'ge-skiller:items-long-wait:skip';
     let skipCacheOnce = $state(false);
     let forceLoading = $state(false);
-    let longWaitDialogOpen = $state(false);
-    let pendingLongWaitToggle = $state<null | 'profit' | 'supplies'>(null);
-    let skipLongWaitDialog = $state(false);
-    let doNotAskAgainChecked = $state(false);
     if (typeof window !== 'undefined') {
         const navEntry = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
         const navType = navEntry?.type;
@@ -136,7 +130,6 @@
         const skipFlag = sessionStorage.getItem(cacheSkipKey);
         if (skipFlag) sessionStorage.removeItem(cacheSkipKey);
         skipCacheOnce = shouldSkipForReload || Boolean(skipFlag);
-        skipLongWaitDialog = localStorage.getItem(longWaitSkipKey) === '1';
 
         const markSkip = () => {
             try {
@@ -368,51 +361,6 @@
         itemsPagePreferences.set({ ...$itemsPagePreferences, page: 1 });
     }
 
-    function requestLongWaitToggle(kind: 'profit' | 'supplies', value: boolean) {
-        if (!value) {
-            if (kind === 'profit') {
-                handleProfitModeToggle(false);
-            } else {
-                applySuppliesToggle(false);
-            }
-            return;
-        }
-
-        if (skipLongWaitDialog) {
-            pendingLongWaitToggle = kind;
-            confirmLongWait();
-            return;
-        }
-
-        pendingLongWaitToggle = kind;
-        doNotAskAgainChecked = false;
-        longWaitDialogOpen = true;
-    }
-
-    function confirmLongWait() {
-        if (doNotAskAgainChecked && typeof window !== 'undefined') {
-            try {
-                localStorage.setItem(longWaitSkipKey, '1');
-                skipLongWaitDialog = true;
-            } catch {
-                // ignore storage failures
-            }
-        }
-        if (pendingLongWaitToggle === 'profit') {
-            handleProfitModeToggle(true);
-        } else if (pendingLongWaitToggle === 'supplies') {
-            applySuppliesToggle(true);
-        }
-        pendingLongWaitToggle = null;
-        longWaitDialogOpen = false;
-    }
-
-    function cancelLongWait() {
-        pendingLongWaitToggle = null;
-        doNotAskAgainChecked = false;
-        longWaitDialogOpen = false;
-    }
-
     function handleProfitModeToggle(value: boolean) {
         const nextSortOrder = !value && sortOrderSelected === 'profit-desc' ? 'desc' : sortOrderSelected;
         if (nextSortOrder !== sortOrderSelected) {
@@ -586,12 +534,11 @@
                         Filter by my skill levels
                     </Label>
                 </div>
-                <p class="text-xs text-muted-foreground">Longer wait times:</p>
                 <div class="flex items-center gap-2">
                     <Switch
                         id="supplies-profit-switch"
                         checked={useSuppliesChecked}
-                        onCheckedChange={(value) => requestLongWaitToggle('supplies', value)}
+                        onCheckedChange={applySuppliesToggle}
                         aria-label="Only show what I have supplies for"
                     />
                     <Label for="supplies-profit-switch" class="cursor-pointer select-none text-sm">
@@ -602,7 +549,7 @@
                     <Switch
                         id="profit-mode-switch"
                         checked={profitModeEnabled}
-                        onCheckedChange={(value) => requestLongWaitToggle('profit', value)}
+                        onCheckedChange={handleProfitModeToggle}
                         aria-label="Enable profit mode"
                     />
                     <Label for="profit-mode-switch" class="cursor-pointer select-none text-sm">
@@ -612,32 +559,6 @@
             </div>
         </div>
     </div>
-
-    <AlertDialog.Root bind:open={longWaitDialogOpen}>
-        <AlertDialog.Content>
-            <AlertDialog.Header>
-                <AlertDialog.Title>Longer wait time</AlertDialog.Title>
-                <AlertDialog.Description>
-                    This filter can take 20–60 seconds to process. Do you want to continue?
-                </AlertDialog.Description>
-            </AlertDialog.Header>
-            <AlertDialog.Footer class="flex flex-wrap items-center justify-between gap-3">
-                <div class="flex items-center gap-2 mr-auto">
-                    <input
-                        id="long-wait-skip"
-                        type="checkbox"
-                        class="h-4 w-4 rounded border border-input"
-                        bind:checked={doNotAskAgainChecked}
-                    />
-                    <Label for="long-wait-skip" class="cursor-pointer select-none text-sm">
-                        Do not ask again
-                    </Label>
-                </div>
-                <AlertDialog.Cancel onclick={cancelLongWait}>Cancel</AlertDialog.Cancel>
-                <AlertDialog.Action onclick={confirmLongWait}>Yes, continue</AlertDialog.Action>
-            </AlertDialog.Footer>
-        </AlertDialog.Content>
-    </AlertDialog.Root>
 
     <div class="content-sizing">
         {#snippet pagination()}


### PR DESCRIPTION
## Summary
- Removed the "Longer wait time" confirmation dialog that popped up when toggling on "Only show what I have supplies for" or "Show profit" on the items page, since the underlying slowness has been fixed. The toggles now apply immediately.
- Updated the character save toast: it now reads "Character has been saved" (or "Character has been imported and saved" when the stats were populated via the Wise Old Man import) instead of "Character has been created."

## Test plan
- [x] `npx eslint` on the two changed files — no errors
- [x] `npx svelte-check` — no new errors introduced (pre-existing unrelated errors remain elsewhere in the repo)
- [ ] Manually verify in the browser: toggling "supplies"/"profit" filters on the items page no longer shows a warning dialog, and saving a character (with and without importing) shows the correct toast text


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ma4H8HFLxCCSoRhCAzXszk)_