### PR TITLE
Show investment required on profit cards and add ROI sorting

### DIFF
--- a/src/lib/components/global/item-card.svelte
+++ b/src/lib/components/global/item-card.svelte
@@ -61,6 +61,9 @@
     );
     const profitPercent = $derived(resolveProfitPercent(item));
     const formattedProfitPercent = $derived(formatProfitPercent(profitPercent));
+    const investmentValue = $derived(resolveInvestment(item));
+    const hasInvestment = $derived(investmentValue !== null);
+    const formattedInvestment = $derived(hasInvestment ? formatWithCommas(Math.round(investmentValue!)) : '—');
 
     $effect(() => {
         if (priceTime) timeSincePriceTime = timeSince(priceTime);
@@ -93,6 +96,13 @@
         const profit = item.creationProfit;
         if (typeof profit !== 'number' || !Number.isFinite(profit)) return null;
         return profit;
+    }
+
+    /** The gp that has to be fronted to create the item, i.e. the cost of its ingredients. */
+    function resolveInvestment(item: IGameItem): number | null {
+        const cost = item.creationCost;
+        if (typeof cost !== 'number' || !Number.isFinite(cost) || cost < 0) return null;
+        return cost;
     }
 
     function resolveProfitPercent(item: IGameItem): number | null {
@@ -172,6 +182,16 @@
                             {#if formattedProfitPercent}
                                 <span class="text-muted-foreground">({formattedProfitPercent})</span>
                             {/if}
+                        </span>
+                    </p>
+                {/if}
+                {#if showProfit && hasInvestment}
+                    <p class="text-xs animate-fade-in">
+                        <span class="text-muted-foreground">Investment required:</span>
+                        <span>
+                            <span aria-hidden="true">≤</span>
+                            <span class="sr-only">at most</span>
+                            {formattedInvestment}gp
                         </span>
                     </p>
                 {/if}

--- a/src/lib/components/items/game-items-page.svelte
+++ b/src/lib/components/items/game-items-page.svelte
@@ -31,7 +31,10 @@
     const sortOptions = [
         { value: 'desc', label: 'Sort by value' },
         { value: 'profit-desc', label: 'Sort by profit' },
+        { value: 'roi-desc', label: 'Sort by best ROI' },
     ];
+    // Sort orders that are computed from creation cost, so they need profit mode turned on.
+    const profitSortValues = ['profit-desc', 'roi-desc'];
 
     function normalizeSkillLevels(skillLevels?: CharacterProfile['skillLevels'], hasCharacter = true) {
         if (!hasCharacter) return undefined;
@@ -84,9 +87,7 @@
     let perPageSelected = $state($itemsPagePreferences.perPage || '12');
     let filterSelected = $state($itemsPagePreferences.filter || 'all');
     let sortOrderSelected = $state(
-        $itemsPagePreferences.sortOrder === 'profit-desc' && $itemsPagePreferences.profitMode
-            ? 'profit-desc'
-            : 'desc',
+        normalizeSortSelection($itemsPagePreferences.sortOrder, $itemsPagePreferences.profitMode ?? false),
     );
     let useSuppliesChecked = $state($itemsPagePreferences.useSupplies ?? false);
     let profitModeChecked = $state($itemsPagePreferences.profitMode ?? false);
@@ -326,8 +327,8 @@
     }
 
     function normalizeSortSelection(value?: string | null, profitEnabled = profitModeChecked) {
-        if (value === 'profit-desc') {
-            return profitEnabled ? 'profit-desc' : 'desc';
+        if (value && profitSortValues.includes(value)) {
+            return profitEnabled ? value : 'desc';
         }
         return 'desc';
     }
@@ -362,7 +363,7 @@
     }
 
     function handleProfitModeToggle(value: boolean) {
-        const nextSortOrder = !value && sortOrderSelected === 'profit-desc' ? 'desc' : sortOrderSelected;
+        const nextSortOrder = normalizeSortSelection(sortOrderSelected, value);
         if (nextSortOrder !== sortOrderSelected) {
             sortOrderSelected = nextSortOrder;
         }
@@ -485,7 +486,7 @@
                                     {#each sortOptions as option (option.value)}
                                         <Select.Item
                                             value={option.value}
-                                            disabled={option.value === 'profit-desc' && !profitModeEnabled}
+                                            disabled={profitSortValues.includes(option.value) && !profitModeEnabled}
                                         >
                                             {option.label}
                                         </Select.Item>

--- a/src/lib/models/game-item.ts
+++ b/src/lib/models/game-item.ts
@@ -68,6 +68,7 @@ export type IGameItem = {
         wikiName?: string | null;
         creationCost?: number | null;
         creationProfit?: number | null;
+        creationRoi?: number | null;
     };
 
 /**

--- a/src/lib/services/game-item-mongo-service.server.ts
+++ b/src/lib/services/game-item-mongo-service.server.ts
@@ -224,8 +224,13 @@ export async function getPaginatedGameItems(params?: {
 
     const suppliesFilterActive = suppliesActive || Boolean(supplyMap);
     const shouldComputeProfit = profitDrivenSort || profitMode;
+    const enforceSupplies = profitDrivenSort && suppliesFilterActive;
+    // Enforcing supplies keeps only items the bank already covers in full, so their creation
+    // cost — and with it their ROI — is zero for every survivor. Filtering on ROI as well would
+    // leave nothing at all, so skip it there and let the sort fall through to profit instead.
+    const filterMissingRoi = roiSort && !enforceSupplies;
     const profitStages = shouldComputeProfit
-        ? buildProfitPipeline(supplyMap, profitDrivenSort, profitDrivenSort && suppliesFilterActive, roiSort)
+        ? buildProfitPipeline(supplyMap, profitDrivenSort, enforceSupplies, filterMissingRoi)
         : [];
     const supplyStages = !profitDrivenSort && suppliesFilterActive ? buildSuppliesFilterPipeline(supplyMap) : [];
     // Profit only needs to be computed for every candidate when it drives the sort order;

--- a/src/lib/services/game-item-mongo-service.server.ts
+++ b/src/lib/services/game-item-mongo-service.server.ts
@@ -8,11 +8,12 @@ type GameItemDoc = OsrsboxItemDocument & {
     _id: Types.ObjectId;
     creationCost?: number | null;
     creationProfit?: number | null;
+    creationRoi?: number | null;
 };
 const MAX_INGREDIENT_DEPTH = MAX_ITEM_TREE_DEPTH;
 
 export type GameItemFilter = 'all' | 'members' | 'f2p' | 'equipable' | 'stackable' | 'quest' | 'nonquest';
-export type GameItemSortOrder = 'asc' | 'desc' | 'profit-desc';
+export type GameItemSortOrder = 'asc' | 'desc' | 'profit-desc' | 'roi-desc';
 export type PlayerSkillLevels = Record<string, number>;
 export type PlayerSupplies = Record<string, number>;
 
@@ -189,6 +190,9 @@ export async function getPaginatedGameItems(params?: {
     const sortOrder = normalizeSortOrder(params?.sortOrder);
     const sortDirection = sortOrder === 'asc' ? 1 : -1;
     const profitSort = sortOrder === 'profit-desc';
+    const roiSort = sortOrder === 'roi-desc';
+    // Both profit and ROI sorts are driven by the same creation-cost pipeline.
+    const profitDrivenSort = profitSort || roiSort;
     const profitMode = Boolean(params?.profitMode);
     const baseFilterQuery = getFilterQuery(filter);
     const skillQuery = getSkillMatchQuery(params?.skill);
@@ -204,7 +208,7 @@ export async function getPaginatedGameItems(params?: {
     const supplies = normalizeSupplies(params?.supplies);
     const supplyMap = supplies ?? (suppliesActive ? {} : null);
 
-    if (!skillLevels && !profitSort && !profitMode && !suppliesActive && !supplies) {
+    if (!skillLevels && !profitDrivenSort && !profitMode && !suppliesActive && !supplies) {
         const [items, total] = await Promise.all([
             OsrsboxItemModel.find(filterQuery)
                 .sort({ highPrice: sortDirection, cost: sortDirection, name: 1 })
@@ -219,18 +223,20 @@ export async function getPaginatedGameItems(params?: {
     }
 
     const suppliesFilterActive = suppliesActive || Boolean(supplyMap);
-    const shouldComputeProfit = profitSort || profitMode;
+    const shouldComputeProfit = profitDrivenSort || profitMode;
     const profitStages = shouldComputeProfit
-        ? buildProfitPipeline(supplyMap, profitSort, profitSort && suppliesFilterActive)
+        ? buildProfitPipeline(supplyMap, profitDrivenSort, profitDrivenSort && suppliesFilterActive, roiSort)
         : [];
-    const supplyStages = !profitSort && suppliesFilterActive ? buildSuppliesFilterPipeline(supplyMap) : [];
+    const supplyStages = !profitDrivenSort && suppliesFilterActive ? buildSuppliesFilterPipeline(supplyMap) : [];
     // Profit only needs to be computed for every candidate when it drives the sort order;
     // otherwise it can wait until after pagination and run for just the returned page.
-    const profitStagesBeforeSort = profitSort ? profitStages : [];
-    const profitStagesAfterPagination = profitSort ? [] : profitStages;
-    const sortStage = profitSort
-        ? { creationProfit: sortDirection, highPrice: -1, cost: -1, name: 1 }
-        : { highPrice: sortDirection, cost: sortDirection, name: 1 };
+    const profitStagesBeforeSort = profitDrivenSort ? profitStages : [];
+    const profitStagesAfterPagination = profitDrivenSort ? [] : profitStages;
+    const sortStage = roiSort
+        ? { creationRoi: sortDirection, creationProfit: -1, highPrice: -1, cost: -1, name: 1 }
+        : profitSort
+          ? { creationProfit: sortDirection, highPrice: -1, cost: -1, name: 1 }
+          : { highPrice: sortDirection, cost: sortDirection, name: 1 };
 
     const [{ items, total = 0 } = { items: [], total: 0 }] = await OsrsboxItemModel.aggregate<{
         items: GameItemDoc[];
@@ -320,7 +326,7 @@ function escapeRegex(value: string) {
 }
 
 function normalizeSortOrder(sortOrder?: GameItemSortOrder): GameItemSortOrder {
-    const allowed: GameItemSortOrder[] = ['asc', 'desc', 'profit-desc'];
+    const allowed: GameItemSortOrder[] = ['asc', 'desc', 'profit-desc', 'roi-desc'];
     if (!sortOrder) return 'desc';
     return allowed.includes(sortOrder) ? sortOrder : 'desc';
 }
@@ -373,6 +379,7 @@ function buildProfitPipeline(
     supplies?: PlayerSupplies | null,
     filterMissingProfit: boolean = false,
     enforceSupplies: boolean = false,
+    filterMissingRoi: boolean = false,
 ): Record<string, unknown>[] {
     const supplyMap = supplies ?? normalizeSupplies(supplies);
     const hasSupplies = enforceSupplies || Boolean(supplyMap);
@@ -533,10 +540,30 @@ function buildProfitPipeline(
                 },
             },
         },
+        {
+            // Return on investment as a ratio of profit to the gp that has to be fronted.
+            // Mirrors the percentage the item card renders, so a zero-cost creation (every
+            // ingredient already in the bank) has no meaningful ROI and stays null.
+            $set: {
+                creationRoi: {
+                    $cond: [
+                        {
+                            $and: [{ $ne: ['$creationProfit', null] }, { $gt: ['$creationCost', 0] }],
+                        },
+                        { $divide: ['$creationProfit', '$creationCost'] },
+                        null,
+                    ],
+                },
+            },
+        },
     ];
 
     if (filterMissingProfit) {
         pipeline.push({ $match: { creationProfit: { $ne: null } } });
+    }
+
+    if (filterMissingRoi) {
+        pipeline.push({ $match: { creationRoi: { $ne: null } } });
     }
 
     if (enforceSupplies && hasSupplies) {

--- a/src/routes/api/game-items/+server.ts
+++ b/src/routes/api/game-items/+server.ts
@@ -24,7 +24,10 @@ export const GET: RequestHandler = async ({ url }) => {
     const orderParam = url.searchParams.get('order');
     const normalizedOrder = orderParam === 'profit-asc' ? 'profit-desc' : orderParam;
     const sortOrder: GameItemSortOrder =
-        normalizedOrder === 'asc' || normalizedOrder === 'desc' || normalizedOrder === 'profit-desc'
+        normalizedOrder === 'asc' ||
+        normalizedOrder === 'desc' ||
+        normalizedOrder === 'profit-desc' ||
+        normalizedOrder === 'roi-desc'
             ? normalizedOrder
             : 'desc';
     const skill = url.searchParams.get('skill');


### PR DESCRIPTION
Builds on the profit-mode work merged in #14.

## Investment required on item cards

Profit mode already computed each item's `creationCost` in order to derive profit, but only the profit was surfaced. Cards in profit mode now also show the gp that has to be fronted for the ingredients:

```
Profit: +1,234 gp (+18.7%)
Investment required: ≤ 6,590gp
```

It's rendered as an upper bound (`≤`) because the cost is priced off the ingredients' high prices, so the real spend is at or below it. The `≤` glyph is `aria-hidden` with an "at most" `sr-only` companion so screen readers don't read a bare math symbol. When "Only show what I have supplies for" is on, the figure already excludes what's in the bank — which in that mode means it reads `≤ 0gp`, since the filter only keeps items the bank covers in full.

## Sort by best ROI

New `Sort by best ROI` option in the sort menu, disabled until profit mode is on — same gating as `Sort by profit`. It's powered by the same creation-cost pipeline rather than a second calculation:

- The aggregation gains a `creationRoi` stage: `creationProfit / creationCost`, computed right after `creationProfit`. That's the same ratio the cards already display as a percentage, so the ordering matches what a user reads on the card.
- ROI is `null` when the cost is unknown or zero, and those items are filtered out when ROI drives the sort, mirroring how the profit sort filters out null profit.
- The existing `profitSort` branches became `profitDrivenSort` so ROI reuses the same pre-sort/post-pagination optimization: the profit stages run before `$sort` only when they drive the ordering, and after pagination otherwise.

### Interaction with the supplies filter

Enforcing supplies keeps only items the bank already covers in full, so every survivor has `creationCost === 0` and therefore a null ROI. Applying the ROI filter there would drop exactly those items while `enforceSupplies` dropped the partially-supplied remainder — two disjoint `$match` stages, and an always-empty page. Caught in review and fixed in e9c5381:

```ts
const enforceSupplies = profitDrivenSort && suppliesFilterActive;
const filterMissingRoi = roiSort && !enforceSupplies;
```

Rather than inventing a sentinel for infinite ROI, this lets the sort fall through to the `creationProfit: -1` tiebreaker already in the ROI sort stage — the meaningful ordering once every item is free to make. Outside supplies mode the filter is unchanged.

### Persistence

Sort order survives a reload — `normalizeSortSelection` now handles the whole set of profit-driven sorts instead of just `profit-desc`, which covers restoring the persisted preference, disabling profit mode (any profit-driven sort falls back to `desc`), and the disabled state in the menu.

## Testing

The repo has no test suite, so verification was against the project's own gates:

- `bun run build` — succeeds.
- `bun run check` — 34 errors / 1 warning, identical to the pre-change baseline on `main` (all in files this PR doesn't touch).
- `eslint` on the five changed files — clean. The repo-wide `lint` script still fails on 5 pre-existing errors in untouched files.
- `prettier --check` — `item-card.svelte` is clean; the two files that were already unformatted on `main` are left exactly as they were, so the diff stays focused.

Not exercised against a live database — the ROI aggregation is reviewed by tracing the pipeline rather than run, so the supplies-mode ordering above is worth a look on the deploy preview before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuzpHJeKT5ao7kRfhAZw3g