### PR TITLE
Split item sorting into ROI (percentage) and ROI (value)

### DIFF
--- a/src/lib/components/items/game-items-page.svelte
+++ b/src/lib/components/items/game-items-page.svelte
@@ -29,12 +29,17 @@
         { value: 'nonquest', label: 'Non-quest items' },
     ];
     const sortOptions = [
+        { value: 'roi-desc', label: 'Sort by ROI (percentage)' },
+        { value: 'roi-value-desc', label: 'Sort by ROI (value)' },
         { value: 'desc', label: 'Sort by value' },
-        { value: 'profit-desc', label: 'Sort by profit' },
-        { value: 'roi-desc', label: 'Sort by best ROI' },
     ];
     // Sort orders that are computed from creation cost, so they need profit mode turned on.
-    const profitSortValues = ['profit-desc', 'roi-desc'];
+    const profitSortValues = ['roi-desc', 'roi-value-desc'];
+    // Retired sort orders still sitting in persisted preferences or bookmarked URLs.
+    const legacySortValues: Record<string, string> = {
+        'profit-asc': 'roi-value-desc',
+        'profit-desc': 'roi-value-desc',
+    };
 
     function normalizeSkillLevels(skillLevels?: CharacterProfile['skillLevels'], hasCharacter = true) {
         if (!hasCharacter) return undefined;
@@ -327,8 +332,10 @@
     }
 
     function normalizeSortSelection(value?: string | null, profitEnabled = profitModeChecked) {
-        if (value && profitSortValues.includes(value)) {
-            return profitEnabled ? value : 'desc';
+        if (!value) return 'desc';
+        const resolved = legacySortValues[value] ?? value;
+        if (profitSortValues.includes(resolved)) {
+            return profitEnabled ? resolved : 'desc';
         }
         return 'desc';
     }
@@ -554,7 +561,7 @@
                         aria-label="Enable profit mode"
                     />
                     <Label for="profit-mode-switch" class="cursor-pointer select-none text-sm">
-                        Show profit <span class="text-xs text-muted-foreground">(enables profit sorting)</span>
+                        Show profit <span class="text-xs text-muted-foreground">(enables ROI sorting)</span>
                     </Label>
                 </div>
             </div>

--- a/src/lib/services/game-item-mongo-service.server.ts
+++ b/src/lib/services/game-item-mongo-service.server.ts
@@ -13,7 +13,13 @@ type GameItemDoc = OsrsboxItemDocument & {
 const MAX_INGREDIENT_DEPTH = MAX_ITEM_TREE_DEPTH;
 
 export type GameItemFilter = 'all' | 'members' | 'f2p' | 'equipable' | 'stackable' | 'quest' | 'nonquest';
-export type GameItemSortOrder = 'asc' | 'desc' | 'profit-desc' | 'roi-desc';
+export type GameItemSortOrder = 'asc' | 'desc' | 'roi-desc' | 'roi-value-desc';
+
+/** Sort orders that used to be exposed, kept working for bookmarked URLs and persisted preferences. */
+const LEGACY_SORT_ORDERS: Record<string, GameItemSortOrder> = {
+    'profit-asc': 'roi-value-desc',
+    'profit-desc': 'roi-value-desc',
+};
 export type PlayerSkillLevels = Record<string, number>;
 export type PlayerSupplies = Record<string, number>;
 
@@ -187,12 +193,12 @@ export async function getPaginatedGameItems(params?: {
     const perPage = Math.max(1, Math.min(200, params?.perPage ?? 12));
     const skip = (page - 1) * perPage;
     const filter = normalizeFilter(params?.filter);
-    const sortOrder = normalizeSortOrder(params?.sortOrder);
+    const sortOrder = parseSortOrder(params?.sortOrder);
     const sortDirection = sortOrder === 'asc' ? 1 : -1;
-    const profitSort = sortOrder === 'profit-desc';
+    const roiValueSort = sortOrder === 'roi-value-desc';
     const roiSort = sortOrder === 'roi-desc';
-    // Both profit and ROI sorts are driven by the same creation-cost pipeline.
-    const profitDrivenSort = profitSort || roiSort;
+    // Both ROI sorts are driven by the same creation-cost pipeline.
+    const profitDrivenSort = roiValueSort || roiSort;
     const profitMode = Boolean(params?.profitMode);
     const baseFilterQuery = getFilterQuery(filter);
     const skillQuery = getSkillMatchQuery(params?.skill);
@@ -239,8 +245,8 @@ export async function getPaginatedGameItems(params?: {
     const profitStagesAfterPagination = profitDrivenSort ? [] : profitStages;
     const sortStage = roiSort
         ? { creationRoi: sortDirection, creationProfit: -1, highPrice: -1, cost: -1, name: 1 }
-        : profitSort
-          ? { creationProfit: sortDirection, highPrice: -1, cost: -1, name: 1 }
+        : roiValueSort
+          ? { creationProfit: sortDirection, creationRoi: -1, highPrice: -1, cost: -1, name: 1 }
           : { highPrice: sortDirection, cost: sortDirection, name: 1 };
 
     const [{ items, total = 0 } = { items: [], total: 0 }] = await OsrsboxItemModel.aggregate<{
@@ -330,10 +336,15 @@ function escapeRegex(value: string) {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function normalizeSortOrder(sortOrder?: GameItemSortOrder): GameItemSortOrder {
-    const allowed: GameItemSortOrder[] = ['asc', 'desc', 'profit-desc', 'roi-desc'];
+/**
+ * Resolves an arbitrary sort-order string (query param, persisted preference) to a supported
+ * sort order, translating retired values and falling back to the default high-price sort.
+ */
+export function parseSortOrder(sortOrder?: string | null): GameItemSortOrder {
     if (!sortOrder) return 'desc';
-    return allowed.includes(sortOrder) ? sortOrder : 'desc';
+    const resolved = LEGACY_SORT_ORDERS[sortOrder] ?? sortOrder;
+    const allowed: GameItemSortOrder[] = ['asc', 'desc', 'roi-desc', 'roi-value-desc'];
+    return allowed.includes(resolved as GameItemSortOrder) ? (resolved as GameItemSortOrder) : 'desc';
 }
 
 function normalizeFilter(filter?: GameItemFilter): GameItemFilter {

--- a/src/routes/api/game-items/+server.ts
+++ b/src/routes/api/game-items/+server.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import {
     getGameItems,
     getPaginatedGameItems,
+    parseSortOrder,
     type GameItemFilter,
     type GameItemSortOrder,
     type PlayerSupplies,
@@ -21,15 +22,7 @@ export const GET: RequestHandler = async ({ url }) => {
     const page = Number(url.searchParams.get('page')) || 1;
     const perPage = Number(url.searchParams.get('perPage')) || 50;
     const filter = (url.searchParams.get('filter') ?? undefined) as GameItemFilter | undefined;
-    const orderParam = url.searchParams.get('order');
-    const normalizedOrder = orderParam === 'profit-asc' ? 'profit-desc' : orderParam;
-    const sortOrder: GameItemSortOrder =
-        normalizedOrder === 'asc' ||
-        normalizedOrder === 'desc' ||
-        normalizedOrder === 'profit-desc' ||
-        normalizedOrder === 'roi-desc'
-            ? normalizedOrder
-            : 'desc';
+    const sortOrder: GameItemSortOrder = parseSortOrder(url.searchParams.get('order'));
     const skill = url.searchParams.get('skill');
     const skillLevelsParam = url.searchParams.get('skillLevels');
     let skillLevels: PlayerSkillLevels | undefined;


### PR DESCRIPTION
## What changed

The items page sort dropdown now offers ROI as an explicit pair, percentage first:

| Option | Sorts on |
| --- | --- |
| Sort by ROI (percentage) | `creationRoi` — profit as a share of the gp fronted |
| Sort by ROI (value) | `creationProfit` — raw gp returned per creation |
| Sort by value | `highPrice` (unchanged default) |

## Why

The dropdown previously had "Sort by profit" and "Sort by best ROI". Those are the same return measured two different ways, but nothing in the labels said so, and "best ROI" didn't say whether it ranked by percentage or by gp. Naming them as one ROI pair makes the distinction obvious. Percentage is listed first because the ratio is the more useful ranking — it surfaces efficient flips rather than just expensive items.

The gp-denominated option is the old profit sort under a clearer name, so this is a relabel plus reorder rather than a new metric; there is no separate "profit" entry left, since a duplicate of ROI (value) under another name is exactly the ambiguity this removes.

## Details

- Added the `roi-value-desc` sort order (`GameItemSortOrder`), sorting on `creationProfit` descending with `creationRoi` as the new tie-break before price.
- Retired `profit-desc` / `profit-asc` to aliases of `roi-value-desc`, both server-side (`LEGACY_SORT_ORDERS`) and client-side (`legacySortValues`), so bookmarked API URLs and sort orders already persisted in `localStorage` keep working and get rewritten to the new value on load.
- Centralized sort-order parsing in an exported `parseSortOrder`, replacing the inline chain of equality checks in the API route and the private `normalizeSortOrder` in the query layer.
- Updated the profit-mode switch hint to "(enables ROI sorting)" to match the renamed options.

Both ROI sorts still require profit mode, and still run through the same creation-cost pipeline — that behavior is unchanged.

## Testing

- `bun run check` — 34 errors, identical to the count on `main` before these changes; none in the touched files' new code.
- `bun run lint` — 5 errors, all pre-existing and in unrelated files.
- `bunx prettier --check` on the touched files — the reported diffs are all on pre-existing lines, none on lines added here.
- `bun run build` — succeeds.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LnuZ6qpsTyvmJJXVhtBKNN)_