### PR TITLE
feat: Ironman mode — planning docs and first implementation

### DIFF
--- a/docs/ironman-feature-recommendations.md
+++ b/docs/ironman-feature-recommendations.md
@@ -262,8 +262,8 @@ const highAlchProfit = $derived(() => {
 ```
 
 That is a merchant's alch-flip metric: profit from buying at GE price and alching. An Ironman never
-bought it at GE price. Under Ironman mode the correct number is `highalch − nature rune cost`, and it
-should be labelled as such. Small change, and it removes a number that is actively wrong for this
+bought it at GE price. Under Ironman mode the correct number is `highalch − nature rune cost`, shown
+as **High alch value** rather than as a profit figure. Small change, and it removes a number that is actively wrong for this
 audience.
 
 ### 4.3 Cheapest-XP sorting (small, uses data already present)

--- a/docs/ironman-feature-recommendations.md
+++ b/docs/ironman-feature-recommendations.md
@@ -149,13 +149,18 @@ cannot do.
 
 **The math change.**
 
-|              | Current                         | Ironman mode                                                 |
-| ------------ | ------------------------------- | ------------------------------------------------------------ |
-| Input cost   | `Σ ingredient GE price × qty`   | `Σ (shop price if shop-buyable, else 0 gp + a "gather" tag)` |
-| Output value | `highPrice ?? lowPrice ?? cost` | `max(best shop buy price, highalch − nature rune cost, 0)`   |
+|              | Current                         | Ironman mode                                                   |
+| ------------ | ------------------------------- | -------------------------------------------------------------- |
+| Input cost   | `Σ ingredient GE price × qty`   | `Σ ingredient valueBasis × qty` (what the materials are worth) |
+| Gp fronted   | — (same as input cost)          | `Σ shop price × qty` for shop-buyable inputs only              |
+| Output value | `highPrice ?? lowPrice ?? cost` | `max(best shop buy price, highalch − nature rune cost, 0)`     |
 
-Self-gathered inputs cost 0 gp but are not free — they cost time. Tag them rather than pricing them,
-and let the gp column stay honest.
+Ironman mode needs **two** input numbers, not one. Gp fronted is what a shopkeeper takes, and it is
+zero for a fully gathered recipe — that's the number for "how much am I risking". Input cost is what
+the consumed materials are worth, which is never zero for a real recipe, and it's what profit and ROI
+divide by: gathered materials aren't free, they had a sale value you gave up by crafting with them.
+Using gp-fronted as the ROI denominator is what makes ROI collapse to `null` on most Ironman rows.
+See §2.3.1 of the UI plan for the full definition.
 
 **Where it lands.**
 
@@ -163,9 +168,9 @@ and let the gp column stay honest.
   and a toggle in the switch group in `game-items-page.svelte`, alongside the existing
   `profitMode` / `useSupplies` switches.
 - Thread `ironman=1` through `/api/game-items` exactly as `profitMode` is threaded today.
-- Server-side, branch `buildProfitPipeline()` to read the precomputed `ironmanCost` / `ironmanExitValue`
-  fields rather than GE prices.
-- Relabel in `item-card.svelte`: "Profit" → "Ironman profit", "Investment required" → "Shop cost".
+- Server-side, branch `buildProfitPipeline()` to read the precomputed `ironmanInputValue` /
+  `ironmanGpSpent` / `ironmanExitValue` / `ironmanProfit` / `ironmanRoi` fields rather than GE prices.
+- Relabel in `item-card.svelte`: "Profit" → "Ironman profit", "Investment required" → "Materials".
 
 **Scope note.** This should be a genuine mode, not just a formula swap — under Ironman mode the base
 filter must also stop excluding untradeables (finding #1 above), and items whose inputs are neither
@@ -272,11 +277,13 @@ The honest Ironman metric is rarely profit — most Ironman crafting is net-nega
 they optimise is **gp lost per XP gained**. `experienceGranted` is already on every creation spec, so:
 
 ```
-gpPerXp = (ironmanCost − ironmanExitValue) / totalXp
+gpPerXp = (ironmanInputValue − ironmanExitValue) / totalXp
 ```
 
-Add "Least gp per XP" to `sortOptions` and a gp/XP line to the item card. Works immediately with a
-0-cost-gathered assumption and gets sharper once shop data lands.
+Add "Least gp per XP" to `sortOptions` and a gp/XP line to the item card. This sits alongside ROI
+rather than replacing it — ROI answers "is processing these materials worth it", gp-per-XP answers
+"what does this level cost me". Works immediately with a 0-cost-gathered assumption and gets sharper
+once shop data lands.
 
 ### 4.4 Bank → XP planner (most novel; no new data)
 

--- a/docs/ironman-feature-recommendations.md
+++ b/docs/ironman-feature-recommendations.md
@@ -1,0 +1,330 @@
+# Ironman feature recommendations
+
+A scan of the app's data, services and UI against what Ironman accounts actually need, plus specs for
+the four requested features and five more worth adding.
+
+---
+
+## 1. What the app knows today
+
+Everything lives in one Mongo collection (`items`), modelled by
+`src/lib/models/mongo-schemas/osrsbox-db-item-schema.ts`.
+
+**From OSRSBox** — `id`, `name`, `icon`, `examine`, `members`, `tradeable`, `tradeable_on_ge`,
+`stackable`, `noted`/`noteable`, `linked_id_*`, `placeholder`, `equipable*`, **`cost`**, **`lowalch`**,
+**`highalch`**, `weight`, **`buy_limit`**, `quest_item`, `release_date`, `wiki_name`, `wiki_url`,
+`equipment`, `weapon`.
+
+**Added by this repo**
+
+| Field                                             | Written by                                                                                   | Notes                                                                                                             |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `highPrice` / `highTime` / `lowPrice` / `lowTime` | `netlify/functions/update-item-prices` → `game-item-price-service.ts`                        | Hourly, from `prices.runescape.wiki`                                                                              |
+| `creationSpecs[]`                                 | `scripts/populate-ingredients.ts` (using the wiki spider in `scripts/osrs-wiki-creation.ts`) | `requiredSkills[]`, `experienceGranted[]`, `ingredients[]` (`{ item: ObjectId, amount, consumedDuringCreation }`) |
+| `creationSpecs[].treeMinSkills`                   | `scripts/compute-creation-tree-skills.ts`                                                    | Precomputed batch field — the precedent for everything proposed below                                             |
+
+**Computed per request** — `creationCost`, `creationProfit`, `creationRoi`, built in
+`buildProfitPipeline()` in `game-item-mongo-service.server.ts` via a `$lookup` on ingredients and
+`allowDiskUse(true)`.
+
+**Client state** — character profiles + skill levels, a per-character bank/supplies list
+(`bank-items-store.ts`), favorites, hidden, and items-page preferences (`filter`, `sortOrder`,
+`perPage`, `page`, `useSupplies`, `profitMode`).
+
+### What is missing
+
+- **All shop data.** Nothing in the repo knows which NPC shops buy or sell an item, at what
+  percentage, with what stock or restock rate. This is the single blocker for three of the four
+  requested features.
+- **Non-GE acquisition.** No drop tables, no gathering sources (rock/tree/fishing spot + level), no
+  quest/minigame unlocks.
+- **Time.** No actions-per-hour or XP-rate data, so nothing can be expressed per hour yet.
+
+### Three findings that matter before any feature work
+
+1. **Ironman-relevant items are invisible today.** Every listing and search path hard-filters
+   `tradeable_on_ge: true` **and** requires a live GE price:
+
+    ```ts
+    // game-item-mongo-service.server.ts
+    const filterQuery = mergeQueries(baseFilterQuery, skillQuery, {
+        placeholder: false,
+        noted: false,
+        stacked: null,
+        tradeable_on_ge: true,
+        ...getValidPriceQuery(), // $or: [{ highPrice: { $gt: 0 } }, { lowPrice: { $gt: 0 } }]
+    });
+    ```
+
+    `searchGameItems()` applies the same `baseFilter`. So untradeables and anything without a recent
+    GE trade cannot be browsed or searched at all — a large slice of what an Ironman makes and uses.
+
+2. **`cost` is the item's base value, not a store price.** The item page renders it as "Store price"
+   with a general-store icon. A general store _sells_ at ~130% of base value and _buys_ at a much
+   lower percentage, so the current row is misleading precisely where feature #2 wants to live.
+   `lowalch`/`highalch` are 40%/60% of `cost`, which confirms `cost` is the value field — and it is
+   the input every shop-price formula needs.
+
+3. **The profit pipeline is already the expensive path.** `creationCost`/`creationProfit`/`creationRoi`
+   are recomputed on every request with a per-document `$lookup`, and the sort spills to disk. Do
+   **not** stack shop math on top of it at query time. Shop-derived values must be **precomputed batch
+   fields** with their own indexes, the way `treeMinSkills` already is.
+
+---
+
+## 2. The unlock: a shop dataset
+
+Features 2, 3 and 4 are one data problem and one formula. Get the data once and all three fall out.
+
+### Mechanics
+
+A shop that buys from players pays a percentage of the item's **base value** (`cost`), not its GE
+price. That percentage starts at the shop's buy rate and steps down for each unit the shop is
+overstocked, down to a floor. Specialty shops pay more than general stores for their specialty stock,
+and most shops refuse items they don't stock at all. Stock drifts back toward default over time,
+which is why the real Ironman play is "sell a batch, hop, sell again".
+
+For base value `V`, buy rate `b₀`, change per unit `δ`, floor fraction `f`:
+
+```
+price of the k-th unit sold   p(k) = floor(V × max(f, b₀ − δ·(k−1)))
+units until the price bottoms  n_floor = ceil((b₀ − f) / δ)
+revenue for a batch of n       R(n) = Σ p(k)
+```
+
+**Do not hardcode `b₀`, `δ` or `f`.** They vary per shop; scrape them per (shop, item) pair. The wiki
+publishes them, and the fact that the wiki ships a `Calculator:Shop calculator` confirms both the
+demand and that the numbers are exposed. What no existing tool does is combine this with a sortable
+item list and creation costs — which is exactly the gap this app sits in.
+
+### Proposed shape
+
+New `shops` collection:
+
+```ts
+{
+  name: 'Bob\'s Brilliant Axes',
+  location: 'Lumbridge',
+  members: false,
+  isGeneralStore: false,
+  buyPercentage: number,      // b₀
+  changePercentage: number,   // δ
+  sellPercentage: number,
+  floorPercentage: number,    // f
+  restockSeconds: number | null,
+  stock: [{ itemId: number, defaultQuantity: number }],
+}
+```
+
+Denormalized onto each item so the browse page can sort and index without a join:
+
+```ts
+shopSources: [{ shopName, location, members, defaultStock,
+                buyPercentage, changePercentage, unitPriceAtDefaultStock }],
+bestShopBuy: { shopName, unitPrice, unitsToFloor } | null,  // indexed
+```
+
+New script `scripts/populate-shops.ts`, wired into `scripts/update-db.ts` as a step after
+`populate-ingredients`. It reuses the existing `wikiApi()` + cheerio section-parsing helpers in
+`scripts/osrs-wiki-creation.ts` — the same pattern as `getCreationSectionIndex` / `parseRequirementsTable`,
+pointed at store-location tables instead of creation tables. Ship this first; it is the dependency for
+three of the four asks.
+
+> Verification note: I could not reach `oldschool.runescape.wiki` from this session (the network egress
+> proxy blocks it), so the exact table markup and the per-shop percentages need confirming on the first
+> local spider run. The mechanics above are well established; the specific numbers are the part to read
+> off the wiki rather than trust from memory.
+
+---
+
+## 3. The four requested features
+
+### 3.1 Ironman mode — zero-trade profit
+
+**Pain.** Every number in the app is a GE number on both sides. For an Ironman both sides are wrong:
+they cannot buy the inputs, and they cannot sell the output. The current "sort by profit" ranking is
+not merely optimistic for an Ironman, it is ranking the wrong items — the top results are usually
+items whose margin exists _because_ the inputs are cheap to buy, which is the one thing an Ironman
+cannot do.
+
+**The math change.**
+
+|              | Current                         | Ironman mode                                                 |
+| ------------ | ------------------------------- | ------------------------------------------------------------ |
+| Input cost   | `Σ ingredient GE price × qty`   | `Σ (shop price if shop-buyable, else 0 gp + a "gather" tag)` |
+| Output value | `highPrice ?? lowPrice ?? cost` | `max(best shop buy price, highalch − nature rune cost, 0)`   |
+
+Self-gathered inputs cost 0 gp but are not free — they cost time. Tag them rather than pricing them,
+and let the gp column stay honest.
+
+**Where it lands.**
+
+- Add `ironmanMode: boolean` to `ItemsPagePreferences` (`src/lib/stores/items-page-preferences.ts`)
+  and a toggle in the switch group in `game-items-page.svelte`, alongside the existing
+  `profitMode` / `useSupplies` switches.
+- Thread `ironman=1` through `/api/game-items` exactly as `profitMode` is threaded today.
+- Server-side, branch `buildProfitPipeline()` to read the precomputed `ironmanCost` / `ironmanExitValue`
+  fields rather than GE prices.
+- Relabel in `item-card.svelte`: "Profit" → "Ironman profit", "Investment required" → "Shop cost".
+
+**Scope note.** This should be a genuine mode, not just a formula swap — under Ironman mode the base
+filter must also stop excluding untradeables (finding #1 above), and items whose inputs are neither
+shop-buyable nor gatherable should be filtered out rather than shown with a fake profit.
+
+### 3.2 Item page: non-trade shop section
+
+**Pain.** "An axe sells for 5gp at a general store but 25gp at Bob's Axes" is exactly the information
+an Ironman needs and currently has to leave the app to get.
+
+**Spec.** A third card in the pricing grid on `src/routes/items/[id=integer]/+page.svelte`, beside
+"Grand Exchange" and "Game Prices" — those two sections already exist and this slots in as a peer:
+
+| Shop                 | Location  | Buys at | Sells at | Stock |
+| -------------------- | --------- | ------- | -------- | ----- |
+| Bob's Brilliant Axes | Lumbridge | 25 gp   | 16 gp    | 5     |
+| General store        | (any)     | 5 gp    | 21 gp    | 0     |
+
+Sort best-buying first, badge the best row, and show members/F2P per shop. While in this file, fix
+the "Store price" row to read **"Value"** — it is the base value, and the actual store prices are now
+in the new card.
+
+Under Ironman mode, also swap the "Buy limit" row (a GE concept, meaningless here) for
+**"Shop stock / restock"**.
+
+### 3.3 Items page: sort by merchant buy price, specialists included
+
+**Pain.** No existing tool combines shop-aware pricing with a sortable, filterable list. This is the
+app's clearest differentiator.
+
+**Spec.** Add `Sort by shop value` to `sortOptions` in `game-items-page.svelte`, sorting on the
+precomputed `bestShopBuy.unitPrice` — which is specialist-aware by construction, since the best shop
+is whichever shop pays most, general or specialty.
+
+**Implementation constraint.** Sort on the denormalized `bestShopBuy.unitPrice` field with its own
+index. Computing it inside the request aggregation would mean a second `$lookup` layered on the one
+already spilling to disk. Add to the schema:
+
+```ts
+osrsboxItemSchema.index({ tradeable_on_ge: 1, placeholder: 1, noted: 1, 'bestShopBuy.unitPrice': -1 });
+```
+
+Show the shop name on the card so "25gp — Bob's Brilliant Axes" is visible without opening the item.
+
+### 3.4 Item page: how many can I sell before it stops being worth it
+
+**Pain.** Real, and currently a wiki round-trip. Worth flagging one thing about how it's framed, then
+building it either way:
+
+> The break-even framing assumes a cost basis. For most Ironmen making the item from gathered
+> materials, the cost basis is **0 gp** — so the marginal-profit break-even is infinite and the
+> question silently becomes a different one: _how many until the price bottoms out?_
+
+So surface **two** numbers and let the cost basis decide which one leads:
+
+- **Units until the price floors** — `n_floor = ceil((b₀ − f)/δ)`. Always meaningful. This is the
+  number a gathered-materials Ironman actually wants.
+- **Units until unit price < creation cost** — the largest `n` where `p(n) ≥ creationCost`. Shown only
+  when creation cost > 0, i.e. when they actually fronted gp.
+
+Plus, because these are all one trip in practice: **total gp for the full batch** — `R(n)` — and the
+restock time, so the answer reads "sell 10 here for 1,840 gp, then hop" rather than a bare number.
+
+Render as a small block under the shop table, driven by the same `shopSources` data — no extra
+fetches. The cost basis is already available: `creationCost` is computed for the item, and if
+`useSupplies` is on for a character it is already net of what's in their bank.
+
+---
+
+## 4. Five more worth adding
+
+Ranked by value-to-effort.
+
+### 4.1 Stop hiding untradeables (highest leverage, no new data)
+
+Finding #1 above. Under Ironman mode, relax the base filter in `getFilterQuery()` /
+`getValidPriceQuery()` and in `searchGameItems()`'s `baseFilter` so untradeables and items without a
+live GE price are browsable and searchable. Right now an Ironman cannot even look up a large share of
+what they make. This is a filter change, not a feature build, and it makes every other Ironman feature
+apply to the right item set.
+
+### 4.2 Fix alch profit for Ironmen (no new data)
+
+The item page computes:
+
+```ts
+// src/routes/items/[id=integer]/+page.svelte
+const highAlchProfit = $derived(() => {
+    const alch = gameItem?.highalch;
+    const price = normalizePrice(gameItem?.highPrice);
+    if (alch === null || alch === undefined || price === null) return null;
+    return alch - price;
+});
+```
+
+That is a merchant's alch-flip metric: profit from buying at GE price and alching. An Ironman never
+bought it at GE price. Under Ironman mode the correct number is `highalch − nature rune cost`, and it
+should be labelled as such. Small change, and it removes a number that is actively wrong for this
+audience.
+
+### 4.3 Cheapest-XP sorting (small, uses data already present)
+
+The honest Ironman metric is rarely profit — most Ironman crafting is net-negative gp on purpose. What
+they optimise is **gp lost per XP gained**. `experienceGranted` is already on every creation spec, so:
+
+```
+gpPerXp = (ironmanCost − ironmanExitValue) / totalXp
+```
+
+Add "Least gp per XP" to `sortOptions` and a gp/XP line to the item card. Works immediately with a
+0-cost-gathered assumption and gets sharper once shop data lands.
+
+### 4.4 Bank → XP planner (most novel; no new data)
+
+`useSupplies` already answers "what can I make with what's in my bank". The unanswered half is **"and
+what would that get me"**. Given the bank contents, the character's levels, and `experienceGranted`,
+compute total XP obtainable per skill from current supplies, plus the net gp delta of doing it.
+
+An Ironman opening the app after a gathering session wants exactly one answer: _what do I do with this
+bank_. Nothing else offers it, and every input already exists in the app — supplies store, character
+levels, `treeMinSkills`, `experienceGranted`. This is the strongest new feature on the list that needs
+no scraping at all.
+
+### 4.5 "Where do I get this?" tags on ingredient rows
+
+The recurring Ironman blocker isn't the recipe, it's sourcing the inputs. Tag each row in
+`game-item-creation-cost-table.svelte` — which already renders exactly these rows — with
+**Shop** / **Gather** / **Drop** / **GE-only**. Shop tags come free with §2's data; gather tags can be
+inferred from the ingredient's own `creationSpecs` skills; drop tags need a further wiki scrape, so
+ship the first two and leave drops for later.
+
+---
+
+## 5. Suggested sequencing
+
+| Order | Work                                                         | Depends on | New data    |
+| ----- | ------------------------------------------------------------ | ---------- | ----------- |
+| 1     | Untradeable/no-price filter fix (§4.1)                       | —          | none        |
+| 2     | Alch-profit fix (§4.2)                                       | —          | none        |
+| 3     | Bank → XP planner (§4.4)                                     | —          | none        |
+| 4     | `scripts/populate-shops.ts` + schema + `update-db` step (§2) | —          | **shops**   |
+| 5     | Item-page shop section (§3.2)                                | 4          | —           |
+| 6     | Break-even / units-to-floor block (§3.4)                     | 4, 5       | —           |
+| 7     | Precompute `bestShopBuy` + sort by shop value (§3.3)         | 4          | —           |
+| 8     | Ironman mode toggle + zero-trade profit (§3.1)               | 4, 7       | —           |
+| 9     | Cheapest-XP sort (§4.3)                                      | 8          | —           |
+| 10    | Ingredient acquisition tags (§4.5)                           | 4          | drops later |
+
+Items 1–3 ship without touching the spider and are worth doing regardless. Item 4 is the gate for
+everything else; the next spider run is the natural moment to add it.
+
+## 6. Open questions
+
+- **Which shop, by default?** Best-paying shop overall, nearest shop, or F2P-restricted? Suggest
+  best-paying with a members/F2P badge, and revisit if it proves confusing.
+- **Nature rune cost basis for alch profit.** Ironmen usually craft their own. A fixed configurable
+  value in settings is probably better than pretending there's a market price.
+- **Group Ironman.** Trading within a group is allowed, so GIM sits between the two modes. Worth a
+  third option eventually, not worth designing for now.
+- **Per-hour rates.** Every "best method" question really wants gp/hr and xp/hr. That needs
+  actions-per-hour data the repo doesn't have and the wiki doesn't expose cleanly. Flagging it as the
+  natural next data frontier after shops, not as something to attempt in this round.

--- a/docs/ironman-feature-recommendations.md
+++ b/docs/ironman-feature-recommendations.md
@@ -125,7 +125,10 @@ bestShopBuy: { shopName, unitPrice, unitsToFloor } | null,  // indexed
 ```
 
 New script `scripts/populate-shops.ts`, wired into `scripts/update-db.ts` as a step after
-`populate-ingredients`. It reuses the existing `wikiApi()` + cheerio section-parsing helpers in
+`populate-ingredients`. Scrape by `wiki_page_title` (the real page title PR #16 derives from
+`wiki_url`), never `wiki_name` — OSRSBox synthesises that field for switch-infobox items, and
+requesting it 404s. `scripts/WIKI-NAME-NORMALIZATION.md` has the detail; the creation scraper already
+made this mistake once and it cost ~29% of the catalogue. It reuses the existing `wikiApi()` + cheerio section-parsing helpers in
 `scripts/osrs-wiki-creation.ts` — the same pattern as `getCreationSectionIndex` / `parseRequirementsTable`,
 pointed at store-location tables instead of creation tables. Ship this first; it is the dependency for
 three of the four asks.
@@ -169,7 +172,9 @@ See §2.3.1 of the UI plan for the full definition.
   `profitMode` / `useSupplies` switches.
 - Thread `ironman=1` through `/api/game-items` exactly as `profitMode` is threaded today.
 - Server-side, branch `buildProfitPipeline()` to read the precomputed `ironmanInputValue` /
-  `ironmanGpSpent` / `ironmanExitValue` / `ironmanProfit` / `ironmanRoi` fields rather than GE prices.
+  `ironmanGpSpent` / `ironmanExitValue` / `ironmanProfit` / `ironmanRoi` fields rather than GE prices,
+  and mirror the Ironman unit price beside `resolveIngredientUnitPrice()` in
+  `src/lib/helpers/ingredient-price.ts` (added by PR #16) rather than inlining it in the pipeline.
 - Relabel in `item-card.svelte`: "Profit" → "Ironman profit", "Investment required" → "Materials".
 
 **Scope note.** This should be a genuine mode, not just a formula swap — under Ironman mode the base

--- a/docs/ironman-ui-plan.md
+++ b/docs/ironman-ui-plan.md
@@ -151,22 +151,58 @@ rather than discovered:
 | `Only show what I have supplies for`                | unchanged                                                   |
 | `Filter by my skill levels`                         | unchanged                                                   |
 
-**Sort options.** Two notes here, one of which is a real design consequence:
+**Sort options.**
 
 | Value         | Main label         | Ironman label            |
 | ------------- | ------------------ | ------------------------ |
 | `desc`        | `Sort by value`    | `Sort by sell value`     |
 | `profit-desc` | `Sort by profit`   | `Sort by Ironman profit` |
-| `roi-desc`    | `Sort by best ROI` | **hidden**               |
+| `roi-desc`    | `Sort by best ROI` | `Sort by best ROI`       |
 | `shop-desc`   | —                  | `Sort by shop value`     |
 | `xp-cost-asc` | —                  | `Sort by cheapest XP`    |
 
-**ROI has to be hidden under Ironman, not relabelled.** ROI is `profit / creationCost`, and the
-service already returns `null` when cost is zero. For an Ironman working from gathered materials cost
-_is_ zero, so ROI is undefined for most of the list — the sort would quietly drop the majority of
-results. `Sort by cheapest XP` is the metric that replaces it, and it's the one Ironmen actually
-optimise anyway. Note the existing `normalizeSortSelection()` already falls back to `'desc'` for
-unavailable sorts, so hiding ROI needs the same guard extended rather than new machinery.
+**ROI works under Ironman, but only once the denominator changes.** Today ROI is
+`creationProfit / creationCost`, and the service returns `null` whenever cost is zero. Feed it
+gp-spent as the denominator and an Ironman working from gathered materials divides by zero on most
+rows, so the sort would quietly drop the majority of the list. The fix is to change what the
+denominator measures — see §2.3.1 — not to hide the sort.
+
+#### 2.3.1 What ROI divides by under Ironman
+
+Gp-spent is the wrong denominator for an Ironman, and it's the only reason ROI broke. Materials you
+gathered are not free — they had a sale value you gave up by crafting with them. So under Ironman the
+cost basis becomes **what the consumed inputs are worth**, using each ingredient's own Ironman value:
+
+```
+ironmanInputValue(item) = Σ valueBasis(ingredient) × qty      // over consumed ingredients only
+ironmanProfit           = ironmanExitValue − ironmanInputValue
+ironmanRoi              = ironmanProfit / ironmanInputValue
+```
+
+`valueBasis` is the field already proposed in §0 — `bestShopBuy.unitPrice ?? (highalch − natureRuneCost)`
+— so the same number values an item as an output and prices it as an input. Nothing new to scrape.
+
+This makes ROI meaningful rather than merely defined. It answers the question an Ironman actually has
+in front of a pile of raw materials: **is it worth more processed than raw, and by how much?** A
+craft that turns 1,420 gp of materials into a 1,536 gp item is +8.2%; one that turns them into
+something worth less is negative, and should be — that's real information, not a broken row.
+
+Two consequences worth being deliberate about:
+
+- **Gp actually fronted is still a separate number**, and still worth showing. Keep it as
+  `ironmanGpSpent` — the subset of input value that has to be handed to a shopkeeper. It drives the
+  item card's cost line and the break-even block in §2.6, both of which genuinely mean "gp out of
+  pocket". Do not conflate the two fields.
+- **A residual set still has no ROI.** If every consumed ingredient has a null `valueBasis` — nothing
+  buys it and it can't be alched — input value is zero and ROI stays null. That set is small, where
+  gp-spent-as-denominator made it most of the list. Keep the existing behaviour for it: null sorts
+  out of the ROI list, with the card showing `—`. Worth revisiting only if the coverage count from
+  §0 shows it's larger than expected.
+
+`ironmanProfit` and `ironmanRoi` are precomputed batch fields alongside `bestShopBuy` and indexed for
+sorting, per finding 3 in the recommendations doc — the request-time pipeline never recomputes them.
+
+Main mode is untouched: it keeps GE prices on both sides and gp-spent as its denominator.
 
 ### 2.4 Item card
 
@@ -182,8 +218,8 @@ people distrust the whole page.
 
   1,536gp                          ← exit value
   High alch                        ← source line, replaces the "2 hours ago" timestamp
-  Ironman profit: +410 gp (36.4%)
-  Shop cost: ≤340gp
+  Ironman profit: +116 gp (8.2%)   ← over the value of the materials consumed
+  Materials: 1,420gp · 340gp from shops
 ```
 
 Source line copy, by which basis won:
@@ -192,10 +228,14 @@ Source line copy, by which basis won:
 - `Bob's Brilliant Axes` (the shop name, when a shop pays more)
 - `No sell value` (nothing buys it and it can't be alched)
 
-Cost line copy:
+Cost line copy. It carries both numbers from §2.3.1 — what the materials are worth, and how much of
+that you actually have to pay for:
 
-- `Shop cost: ≤340gp` — when some inputs are shop-bought
-- `Gathered — no gp cost` — when every input is self-gathered
+- `Materials: 1,420gp · 340gp from shops` — when some inputs are shop-bought
+- `Materials: 1,420gp · all gathered` — when nothing has to be bought
+- `Materials: —` — when no consumed ingredient has a value basis
+
+The percentage beside the profit line is `ironmanRoi`, so the card and the ROI sort always agree.
 
 The `timeSince` line is GE-specific and should be dropped under Ironman; shop and alch values don't
 go stale hourly.
@@ -301,7 +341,8 @@ first: it tells us how many items land in each row before we write the states.
 | 5   | Shops card                                                              | Needs shop scrape                                           |
 | 6   | Selling block (§2.6)                                                    | Needs 5                                                     |
 | 7   | Item-card exit value + source line, sort relabels, new sorts            | Needs 5                                                     |
-| 8   | Cheapest-XP sort + gp-per-XP row                                        | Needs 7                                                     |
+| 8   | `ironmanInputValue` / `ironmanRoi` batch fields + ROI sort (§2.3.1)     | Needs 5                                                     |
+| 9   | Cheapest-XP sort + gp-per-XP row                                        | Needs 7                                                     |
 
 Steps 1–4 need no scraping and no new fields, and each is independently shippable. Step 3 is the one
 you asked about, and it's a filter change gated on the mode rather than a data migration.

--- a/docs/ironman-ui-plan.md
+++ b/docs/ironman-ui-plan.md
@@ -153,19 +153,25 @@ rather than discovered:
 
 **Sort options.**
 
-| Value         | Main label         | Ironman label            |
-| ------------- | ------------------ | ------------------------ |
-| `desc`        | `Sort by value`    | `Sort by sell value`     |
-| `profit-desc` | `Sort by profit`   | `Sort by Ironman profit` |
-| `roi-desc`    | `Sort by best ROI` | `Sort by best ROI`       |
-| `shop-desc`   | —                  | `Sort by shop value`     |
-| `xp-cost-asc` | —                  | `Sort by cheapest XP`    |
+| Value            | Main label                 | Ironman label              |
+| ---------------- | -------------------------- | -------------------------- |
+| `desc`           | `Sort by value`            | `Sort by sell value`       |
+| `roi-desc`       | `Sort by ROI (percentage)` | `Sort by ROI (percentage)` |
+| `roi-value-desc` | `Sort by ROI (value)`      | `Sort by ROI (value)`      |
+| `shop-desc`      | —                          | `Sort by shop value`       |
+| `xp-cost-asc`    | —                          | `Sort by cheapest XP`      |
 
-**ROI works under Ironman, but only once the denominator changes.** Today ROI is
+These are the sort orders as PR #16 left them: `profit-desc` was retired in favour of
+`roi-value-desc`, and `legacySortValues` in `game-items-page.svelte` plus `LEGACY_SORT_ORDERS` in the
+service still resolve the old value out of persisted preferences and bookmarked URLs. New Ironman
+sorts must be added to `GameItemSortOrder`, `parseSortOrder()` and `sortOptions` together.
+
+**ROI works under Ironman, but only once the denominator changes.** `creationRoi` is
 `creationProfit / creationCost`, and the service returns `null` whenever cost is zero. Feed it
 gp-spent as the denominator and an Ironman working from gathered materials divides by zero on most
-rows, so the sort would quietly drop the majority of the list. The fix is to change what the
-denominator measures — see §2.3.1 — not to hide the sort.
+rows. Both profit-mode sorts feel it: `roi-desc` sorts on `creationRoi` directly and `filterMissingRoi`
+drops the null rows outright, and `roi-value-desc` uses `creationRoi` as its tiebreaker. The fix is to
+change what the denominator measures — see §2.3.1 — not to hide either sort.
 
 #### 2.3.1 What ROI divides by under Ironman
 
@@ -181,6 +187,12 @@ ironmanRoi              = ironmanProfit / ironmanInputValue
 
 `valueBasis` is the field already proposed in §0 — `bestShopBuy.unitPrice ?? (highalch − natureRuneCost)`
 — so the same number values an item as an output and prices it as an input. Nothing new to scrape.
+
+PR #16 added exactly the seam this needs: `src/lib/helpers/ingredient-price.ts` already centralises
+"what does one unit of an ingredient actually cost", and establishes the principle that `cost` counts
+only where someone can really pay it. The Ironman basis belongs beside `resolveIngredientUnitPrice()`
+as a sibling function sharing its `PricedItem` shape, with the aggregation mirroring it the way
+`buildProfitPipeline()` already mirrors the GE version.
 
 This makes ROI meaningful rather than merely defined. It answers the question an Ironman actually has
 in front of a pile of raw materials: **is it worth more processed than raw, and by how much?** A

--- a/docs/ironman-ui-plan.md
+++ b/docs/ironman-ui-plan.md
@@ -1,0 +1,321 @@
+# Ironman mode — UI plan and copy
+
+Companion to `ironman-feature-recommendations.md`. Covers where the mode lives, what changes on each
+screen, and the exact copy.
+
+---
+
+## 0. Correction: the ingestion scripts are mostly fine
+
+Worth stating up front, because it changes the shape of the work.
+
+`scripts/grab-osrsbox-items.ts` **already imports everything by default**:
+
+```ts
+const SKIP_UNTRADEABLE = process.env.OSRSBOX_SKIP_UNTRADEABLE === 'true';
+const SKIP_NOTED = process.env.OSRSBOX_SKIP_NOTED === 'true';
+// ...
+// Optional filters (default is to import everything).
+if ((SKIP_UNTRADEABLE && !item.tradeable) || (SKIP_NOTED && item.noted)) { … }
+```
+
+Neither env var is set anywhere in the repo, so both default to `false`.
+`scripts/populate-ingredients.ts` builds its `baseFilter` purely from CLI flags and has no tradeable
+filter either. So untradeable items are almost certainly **already in the database, with creation
+specs**. The exclusion is entirely at the query layer in `game-item-mongo-service.server.ts`.
+
+That means the "make the database include Ironman items" work is smaller than it looked, and the real
+work is what the app does with items that have no GE price.
+
+### What does still need changing on the data side
+
+1. **Non-GE items have no price fields at all.** `game-item-price-service.ts` correctly skips
+   `!item.tradeable_on_ge`, so those items have no `highPrice`/`lowPrice` — which is exactly why
+   `getValidPriceQuery()` filters them out. Removing that filter without giving them a value basis
+   just surfaces a list of dashes. **They need `cost`, `highalch` and (once scraped) shop prices as
+   their value basis.** This is the dependency, not the import.
+2. **Add a `valueBasis` precomputed field** in the same batch pass that writes `bestShopBuy`, so every
+   item has a defined non-GE value and the browse page can sort on it:
+   `bestShopBuy.unitPrice ?? (highalch − natureRuneCost) ?? null`.
+3. **Confirm coverage before flipping the filter.** Add a one-off count to
+   `scripts/update-db.ts`'s summary: how many items have `creationSpecs` but no GE price. That number
+   is the size of the unlock and tells us whether it's worth it before any UI ships.
+4. **`backfill-missing-items.ts` is not a route for untradeables** — its skeleton builder pulls from
+   the GE mapping endpoint, which only contains GE-tradeable items, so its hardcoded
+   `tradeable: true, tradeable_on_ge: true` is correct for that source. Leave it alone.
+
+### One reassurance about scope
+
+The browse filter already requires creation specs:
+
+```ts
+const base = { 'creationSpecs.0': { $exists: true } }; // Only items that have creation specs
+```
+
+So dropping `tradeable_on_ge` from **browse** adds untradeable _craftable_ items — a bounded, useful
+set, not a flood. **Search** has no such requirement, so dropping it there opens search to every item
+in the DB. That's desirable (an Ironman wants to look anything up) but it's the path where the
+no-price state below actually matters.
+
+---
+
+## 1. Where the mode lives
+
+**Recommendation: account type is a property of the character profile, not a view preference.**
+
+The app already has multiple character profiles and a character switcher. Ironman status belongs to
+the account, so if someone keeps a main and an iron, switching characters should switch the pricing
+automatically. Burying it as a fourth switch in the items-page toolbar — next to "Filter by my skill
+levels" and "Show profit" — would imply it's a per-page display option, and it would silently
+disagree with itself across the item page, favorites and search.
+
+```ts
+// src/lib/models/player-stats.ts
+export type AccountType = 'main' | 'ironman' | 'hardcore' | 'ultimate' | 'group';
+
+export interface ICharacterProfile {
+    id: UUID;
+    name: string;
+    accountType: AccountType; // new; defaults to 'main' for existing profiles
+    skillLevels: Record<SkillNames, number>;
+}
+```
+
+Branch all pricing on one derived boolean rather than on the enum, so the four Ironman variants can't
+drift apart:
+
+```ts
+const canUseGrandExchange = $derived(accountType === 'main');
+```
+
+Store the full enum anyway — Ultimate needs it later (no bank changes the supplies feature) and Group
+needs it eventually (trading within a group is allowed). Neither changes pricing today.
+
+**When no character is selected**, fall back to `'main'`. A visitor with no profile gets today's
+behaviour unchanged.
+
+**Escape hatch:** if we want people to preview Ironman prices without making a profile, add the
+toggle to the items-page toolbar as an _override_ that defaults to whatever the active character
+says. I'd skip this in v1 — it reintroduces exactly the disagreement the character-level setting
+avoids.
+
+---
+
+## 2. Screen by screen
+
+### 2.1 Character dialog + My character page
+
+The entry point, and the only place the mode is set.
+
+`src/lib/components/dialogs/character-stats-dialog.svelte` and `src/routes/my-character/+page.svelte`
+gain an account-type selector above the skills grid.
+
+> **Account type**
+>
+> - **Main** — Prices come from the Grand Exchange.
+> - **Ironman** — No trading. Items are valued at what shops and alchemy will actually give you.
+> - **Hardcore Ironman** — No trading. Items are valued at what shops and alchemy will actually give you.
+> - **Ultimate Ironman** — No trading and no bank. Items are valued at what shops and alchemy will actually give you.
+> - **Group Ironman** — No trading outside your group. Items are valued at what shops and alchemy will actually give you.
+
+Existing profiles have no `accountType`; default them to `main` on read so nobody's saved characters
+change behaviour on deploy.
+
+### 2.2 Character switcher / site header
+
+`src/lib/components/global/character-switcher.svelte`
+
+The mode must be visible at all times — the worst outcome is someone reading shop-based numbers while
+believing they're GE numbers. Add a small badge beside the character name:
+
+- Badge text: `Ironman` (or `HCIM` / `UIM` / `GIM`)
+- Tooltip: `Ironman — prices don't use the Grand Exchange`
+
+Ironman helm icons would fit the existing `/static/other-images/` convention if we'd rather go visual.
+
+### 2.3 Items page
+
+`src/lib/components/items/game-items-page.svelte`
+
+**A dismissible banner** above the toolbar the first few times, so the number change is explained
+rather than discovered:
+
+> **Ironman prices**
+> Profit here doesn't use the Grand Exchange. Materials you'd gather yourself count as free,
+> materials you'd buy count at shop price, and items are worth what a shop or the alchemy spell will
+> actually pay. [How this is worked out]
+
+**Switch relabels** (only under Ironman; unchanged for mains):
+
+| Today                                               | Under Ironman                                               |
+| --------------------------------------------------- | ----------------------------------------------------------- |
+| `Show profit` <span>(enables profit sorting)</span> | `Show Ironman profit` <span>(enables profit sorting)</span> |
+| `Only show what I have supplies for`                | unchanged                                                   |
+| `Filter by my skill levels`                         | unchanged                                                   |
+
+**Sort options.** Two notes here, one of which is a real design consequence:
+
+| Value         | Main label         | Ironman label            |
+| ------------- | ------------------ | ------------------------ |
+| `desc`        | `Sort by value`    | `Sort by sell value`     |
+| `profit-desc` | `Sort by profit`   | `Sort by Ironman profit` |
+| `roi-desc`    | `Sort by best ROI` | **hidden**               |
+| `shop-desc`   | —                  | `Sort by shop value`     |
+| `xp-cost-asc` | —                  | `Sort by cheapest XP`    |
+
+**ROI has to be hidden under Ironman, not relabelled.** ROI is `profit / creationCost`, and the
+service already returns `null` when cost is zero. For an Ironman working from gathered materials cost
+_is_ zero, so ROI is undefined for most of the list — the sort would quietly drop the majority of
+results. `Sort by cheapest XP` is the metric that replaces it, and it's the one Ironmen actually
+optimise anyway. Note the existing `normalizeSortSelection()` already falls back to `'desc'` for
+unavailable sorts, so hiding ROI needs the same guard extended rather than new machinery.
+
+### 2.4 Item card
+
+`src/lib/components/global/item-card.svelte`
+
+The big number currently renders `highPrice ?? lowPrice`. Under Ironman it renders the exit value,
+and it needs to say where that value came from — a bare number with no source is the thing that makes
+people distrust the whole page.
+
+```
+  Adamant platebody
+  A sturdy platebody.
+
+  1,536gp                          ← exit value
+  High alch                        ← source line, replaces the "2 hours ago" timestamp
+  Ironman profit: +410 gp (36.4%)
+  Shop cost: ≤340gp
+```
+
+Source line copy, by which basis won:
+
+- `High alch`
+- `Bob's Brilliant Axes` (the shop name, when a shop pays more)
+- `No sell value` (nothing buys it and it can't be alched)
+
+Cost line copy:
+
+- `Shop cost: ≤340gp` — when some inputs are shop-bought
+- `Gathered — no gp cost` — when every input is self-gathered
+
+The `timeSince` line is GE-specific and should be dropped under Ironman; shop and alch values don't
+go stale hourly.
+
+### 2.5 Item detail page
+
+`src/routes/items/[id=integer]/+page.svelte`. Four changes, top to bottom.
+
+**Grand Exchange card.**
+
+- Item is untradeable → don't render the card at all.
+- Item is tradeable but the account is an Ironman → collapse it behind a disclosure:
+  `Show Grand Exchange prices` / muted sub-line `You can't use the Grand Exchange on this account.`
+  Worth keeping rather than hiding outright — people do want to know what a thing is "worth".
+
+**New Shops card** (feature #2), a peer of the two existing pricing cards:
+
+> ### Shops
+>
+> | Shop                              | Location  | Buys at | Sells at | Stock |
+> | --------------------------------- | --------- | ------- | -------- | ----- |
+> | Bob's Brilliant Axes `Best price` | Lumbridge | 25 gp   | 16 gp    | 5     |
+> | General store                     | Anywhere  | 5 gp    | 21 gp    | 0     |
+>
+> Empty state: `No shop buys this item.`
+> Members shops carry a `Members` badge.
+
+**Game Prices card.** Rename the `Store price` row to `Value`. It's the item's base value, not a
+store price, and once the Shops card exists next to it the old label is actively contradicted.
+
+**Value insights card.**
+
+| Row                | Main | Ironman                                                         |
+| ------------------ | ---- | --------------------------------------------------------------- |
+| `GE spread`        | keep | hide — it's a merchant metric                                   |
+| `High alch profit` | keep | replace with `High alch value`, sub-label `after 1 nature rune` |
+| `Low alch profit`  | keep | replace with `Low alch value`, sub-label `after 1 nature rune`  |
+| `gp per XP`        | —    | new row                                                         |
+
+**Buy limit row** (in the Grand Exchange card) is a GE concept. Under Ironman it's replaced by
+`Shop stock` / `Restocks every 60s` in the Shops card.
+
+### 2.6 The selling block — answering your question directly
+
+**Yes — new UI on the item page**, and it belongs _inside_ the Shops card rather than as its own
+section, because it's meaningless without knowing which shop you're selling to. It appears under the
+table, keyed to the best-paying shop, with a shop picker if more than one buys the item.
+
+It needs two copy variants, because the number that matters depends on whether gp was fronted:
+
+**When creation cost is zero (gathered materials — the common case):**
+
+> **Selling to Bob's Brilliant Axes**
+> The price drops as you sell. You'll get **25 gp** for the first one, down to **8 gp** by the 10th.
+> Selling all 10 gets you **164 gp**. After that it stays at 8 gp.
+> Stock refills every 60 seconds.
+
+**When creation cost is above zero:**
+
+> **Selling to Bob's Brilliant Axes**
+> Each one costs you **340 gp** to make. The shop pays less for every one you sell, and drops below
+> what you paid after **4**. Selling those 4 gets you **1,420 gp** — a profit of **60 gp**.
+> Stock refills every 60 seconds.
+
+Both are driven by the same `shopSources` data already fetched for the table, so no extra request. The
+cost basis is already available — `creationCost` is computed for the item, and if "Only show what I
+have supplies for" is on it's already net of the character's bank.
+
+---
+
+## 3. The no-price state (the main correctness risk)
+
+Once untradeables are browsable, a whole class of items reaches components that have always assumed a
+price exists. Today `item-card.svelte` renders `—` and `+page.svelte` renders `—` via `formatPrice`,
+which is _safe_ but not _informative_ — a page of dashes reads as broken data.
+
+Every price surface needs a defined, explained empty state:
+
+| Situation                                       | Big number | Sub-line            |
+| ----------------------------------------------- | ---------- | ------------------- |
+| Untradeable, no shop buys it, not alchable      | `—`        | `Nothing buys this` |
+| Untradeable, alchable                           | alch value | `High alch`         |
+| Untradeable, shop buys it                       | shop price | shop name           |
+| Tradeable but no recent GE trade (main account) | `—`        | `No recent trades`  |
+
+That last row exists today and is silently filtered out. Once the filter drops it becomes visible, so
+it needs copy whether or not we ship Ironman mode.
+
+**This is the single highest-risk part of the change** and the reason I'd ship §0's coverage count
+first: it tells us how many items land in each row before we write the states.
+
+---
+
+## 4. Suggested UI build order
+
+| #   | Work                                                                    | Ships value alone?                                          |
+| --- | ----------------------------------------------------------------------- | ----------------------------------------------------------- |
+| 1   | `accountType` on the profile + character-dialog selector + header badge | Yes — mode is visible and settable before anything reads it |
+| 2   | No-price states everywhere (§3)                                         | Yes — fixes a latent gap today                              |
+| 3   | Drop `tradeable_on_ge` from browse + search behind the mode             | Yes — the untradeable unlock                                |
+| 4   | Alch fix + `Value` relabel + hide GE spread                             | Yes — no new data needed                                    |
+| 5   | Shops card                                                              | Needs shop scrape                                           |
+| 6   | Selling block (§2.6)                                                    | Needs 5                                                     |
+| 7   | Item-card exit value + source line, sort relabels, new sorts            | Needs 5                                                     |
+| 8   | Cheapest-XP sort + gp-per-XP row                                        | Needs 7                                                     |
+
+Steps 1–4 need no scraping and no new fields, and each is independently shippable. Step 3 is the one
+you asked about, and it's a filter change gated on the mode rather than a data migration.
+
+---
+
+## 5. Open copy decisions
+
+- **"Sell value" vs "cash value" vs "what you'd get."** I've used `sell value` throughout — shortest
+  thing that's true for both shop and alch exits. Easy to swap, it's one label.
+- **Nature rune cost** needs a home. It's an input to every alch number, and Ironmen craft their own
+  so there's no market price that's really theirs. Suggest a field on the character profile,
+  defaulting to the live GE price of a nature rune, with copy:
+  `Nature rune cost — used for alchemy values. Set this to what a nature rune is worth to you.`
+- **Ironman variants in copy.** Everything above says "Ironman" for all four types. Only Ultimate
+  needs different wording eventually (no bank, so "supplies" means inventory), and that can wait.

--- a/docs/ironman-ui-plan.md
+++ b/docs/ironman-ui-plan.md
@@ -113,10 +113,10 @@ gain an account-type selector above the skills grid.
 > **Account type**
 >
 > - **Main** — Prices come from the Grand Exchange.
-> - **Ironman** — No trading. Items are valued at what shops and alchemy will actually give you.
-> - **Hardcore Ironman** — No trading. Items are valued at what shops and alchemy will actually give you.
-> - **Ultimate Ironman** — No trading and no bank. Items are valued at what shops and alchemy will actually give you.
-> - **Group Ironman** — No trading outside your group. Items are valued at what shops and alchemy will actually give you.
+> - **Ironman** — No economy prices. Prices are shown using alchemy and base shop values (e.g. before the shop value of an item drops from selling multiple).
+> - **Hardcore Ironman** — No economy prices. Prices are shown using alchemy and base shop values (e.g. before the shop value of an item drops from selling multiple).
+> - **Ultimate Ironman** — No economy prices. Prices are shown using alchemy and base shop values (e.g. before the shop value of an item drops from selling multiple). No bank.
+> - **Group Ironman** — No economy prices. Prices are shown using alchemy and base shop values (e.g. before the shop value of an item drops from selling multiple). Trading is limited to your group.
 
 Existing profiles have no `accountType`; default them to `main` on read so nobody's saved characters
 change behaviour on deploy.
@@ -140,10 +140,8 @@ Ironman helm icons would fit the existing `/static/other-images/` convention if 
 **A dismissible banner** above the toolbar the first few times, so the number change is explained
 rather than discovered:
 
-> **Ironman prices**
-> Profit here doesn't use the Grand Exchange. Materials you'd gather yourself count as free,
-> materials you'd buy count at shop price, and items are worth what a shop or the alchemy spell will
-> actually pay. [How this is worked out]
+> **You're in Ironman mode.** The GP values shown in Ironman mode are derived from alchemy and base
+> shop values (e.g. before the shop value of an item drops from selling multiple).
 
 **Switch relabels** (only under Ironman; unchanged for mains):
 
@@ -209,9 +207,10 @@ go stale hourly.
 **Grand Exchange card.**
 
 - Item is untradeable → don't render the card at all.
-- Item is tradeable but the account is an Ironman → collapse it behind a disclosure:
-  `Show Grand Exchange prices` / muted sub-line `You can't use the Grand Exchange on this account.`
-  Worth keeping rather than hiding outright — people do want to know what a thing is "worth".
+- Item is tradeable but the account is an Ironman → deprioritise it rather than annotate it. Order
+  the card below the Shops card and collapse it behind a plain `Show Grand Exchange prices`
+  disclosure, with no explanatory sub-line. It's still real information and people do want to know
+  what a thing is "worth" — it just isn't the number they act on.
 
 **New Shops card** (feature #2), a peer of the two existing pricing cards:
 
@@ -230,12 +229,12 @@ store price, and once the Shops card exists next to it the old label is actively
 
 **Value insights card.**
 
-| Row                | Main | Ironman                                                         |
-| ------------------ | ---- | --------------------------------------------------------------- |
-| `GE spread`        | keep | hide — it's a merchant metric                                   |
-| `High alch profit` | keep | replace with `High alch value`, sub-label `after 1 nature rune` |
-| `Low alch profit`  | keep | replace with `Low alch value`, sub-label `after 1 nature rune`  |
-| `gp per XP`        | —    | new row                                                         |
+| Row                | Main | Ironman                        |
+| ------------------ | ---- | ------------------------------ |
+| `GE spread`        | keep | hide — it's a merchant metric  |
+| `High alch profit` | keep | replace with `High alch value` |
+| `Low alch profit`  | keep | replace with `Low alch value`  |
+| `gp per XP`        | —    | new row                        |
 
 **Buy limit row** (in the Grand Exchange card) is a GE concept. Under Ironman it's replaced by
 `Shop stock` / `Restocks every 60s` in the Shops card.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "update-item-prices": "bun run --env-file .env scripts/run-update-item-prices.ts",
         "remove-duplicate-items": "bun run --env-file .env scripts/remove-duplicate-items.ts",
         "normalize-wiki-names": "bun run --env-file .env scripts/normalize-wiki-names.ts",
+        "repair-ingredient-links": "bun run --env-file .env scripts/repair-ingredient-links.ts",
         "copy-osrsbox-to-dev": "OSRSBOX_SOURCE_DB=osrsbox OSRSBOX_TARGET_DB=osrsbox-dev bun run --env-file .env scripts/copy-osrsbox-db.ts",
         "copy-osrsbox-dev-to-prod": "OSRSBOX_SOURCE_DB=osrsbox-dev OSRSBOX_TARGET_DB=osrsbox-prod bun run --env-file .env scripts/copy-osrsbox-db.ts",
         "update-db": "bun run --env-file .env scripts/update-db.ts",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "populate-item-ingredient-trees": "bun run --env-file .env scripts/populate-ingredients.ts",
         "update-item-prices": "bun run --env-file .env scripts/run-update-item-prices.ts",
         "remove-duplicate-items": "bun run --env-file .env scripts/remove-duplicate-items.ts",
+        "normalize-wiki-names": "bun run --env-file .env scripts/normalize-wiki-names.ts",
         "copy-osrsbox-to-dev": "OSRSBOX_SOURCE_DB=osrsbox OSRSBOX_TARGET_DB=osrsbox-dev bun run --env-file .env scripts/copy-osrsbox-db.ts",
         "copy-osrsbox-dev-to-prod": "OSRSBOX_SOURCE_DB=osrsbox-dev OSRSBOX_TARGET_DB=osrsbox-prod bun run --env-file .env scripts/copy-osrsbox-db.ts",
         "update-db": "bun run --env-file .env scripts/update-db.ts",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "copy-osrsbox-dev-to-prod": "OSRSBOX_SOURCE_DB=osrsbox-dev OSRSBOX_TARGET_DB=osrsbox-prod bun run --env-file .env scripts/copy-osrsbox-db.ts",
         "update-db": "bun run --env-file .env scripts/update-db.ts",
         "compute-creation-tree-skills": "bun run --env-file .env scripts/compute-creation-tree-skills.ts",
+        "test": "bun test",
         "format": "prettier --write ."
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "remove-duplicate-items": "bun run --env-file .env scripts/remove-duplicate-items.ts",
         "normalize-wiki-names": "bun run --env-file .env scripts/normalize-wiki-names.ts",
         "repair-ingredient-links": "bun run --env-file .env scripts/repair-ingredient-links.ts",
+        "rescrape-creation-specs": "bun run --env-file .env scripts/rescrape-creation-specs.ts",
         "copy-osrsbox-to-dev": "OSRSBOX_SOURCE_DB=osrsbox OSRSBOX_TARGET_DB=osrsbox-dev bun run --env-file .env scripts/copy-osrsbox-db.ts",
         "copy-osrsbox-dev-to-prod": "OSRSBOX_SOURCE_DB=osrsbox-dev OSRSBOX_TARGET_DB=osrsbox-prod bun run --env-file .env scripts/copy-osrsbox-db.ts",
         "update-db": "bun run --env-file .env scripts/update-db.ts",

--- a/scripts/INGREDIENT-LINK-REPAIR.md
+++ b/scripts/INGREDIENT-LINK-REPAIR.md
@@ -89,3 +89,56 @@ scrape reintroduces the bad links.
 - Confirmed against the live dataset that **0 of 8,437** multi-document names lack a
   non-duplicate candidate, so the ranking always has something canonical to pick.
   1,126 names remain ambiguous after the flag checks and rely on the id tiebreak.
+
+## Applied
+
+Run against the `osrsbox` master DB on 2026-08-21, after the `--versioned-only`
+re-scrape completed:
+
+```
+Ingredient links inspected ......... 43,041
+Links repointed to canonical .......  1,624
+Items written ......................  1,138
+```
+
+A second dry run reported 0 links to move, confirming idempotency. `Oak seedling (w)`
+now prices its `Acorn` from canonical id 5312 (139gp) rather than the unpriced
+duplicate 5111.
+
+## Known issue: self-referential specs from wiki variants
+
+The re-scrape surfaced a **separate** resolution bug that this repair does not address.
+`find-ingredient-cycles` now reports 846 cycles, up from 258, and **414 of them are
+self-loops** — an item listing itself as its own ingredient:
+
+```
+Apple seedling (w)  <-  Apple seedling (w) + Watering can
+```
+
+The real recipe is _unwatered_ seedling + watering can. Both variants live on one wiki
+page, and lookup-key normalization strips the `(w)` suffix, so the ingredient resolves
+back to the watered item itself. This is a name-collision between infobox variants,
+distinct from the duplicate-document problem `pickPreferredItem` solves — the chosen
+document is canonical, it is just the wrong variant.
+
+**Do not run `find-ingredient-cycles` to paper over this.** It removes whole
+`creationSpecs` entries whose ingredients close a cycle, and against the current data
+that means:
+
+|                                       |         |
+| ------------------------------------- | ------- |
+| Creation specs removed                | 1,065   |
+| Items affected                        | 464     |
+| **Items losing every spec they have** | **181** |
+
+Those 181 include `Yellow cape` (7 specs), `Dragon dagger(p++)` (3), `Staff of water`
+(3) and `Candle lantern` (4) — real recipes destroyed to break a cycle that only exists
+because of the variant collision. The cycles step was deliberately skipped in the run
+above.
+
+Skipping it is safe: `compute-creation-tree-skills` guards itself, breaking recursion
+via a `stack.has(key)` check and returning an empty skill range. It completed all 28,763
+items and reported 3,230 cycle hits without failing.
+
+The real fix is to resolve an ingredient to the variant the wiki actually names, using
+`wiki_version` to disambiguate rather than collapsing variants to one lookup key.

--- a/scripts/INGREDIENT-LINK-REPAIR.md
+++ b/scripts/INGREDIENT-LINK-REPAIR.md
@@ -1,0 +1,91 @@
+# Canonical ingredient resolution
+
+## The problem
+
+Ingredient references stored in `creationSpecs` pointed at OSRSBox documents that carry
+no Grand Exchange price, so anything crafted from them priced as free.
+
+A name in the OSRSBox dataset can cover many in-game item ids. `Acorn` is:
+
+| id        | `duplicate` | `placeholder` | `tradeable_on_ge` | price     |
+| --------- | ----------- | ------------- | ----------------- | --------- |
+| 5111-5114 | yes         | no            | no                | —         |
+| **5312**  | **no**      | **no**        | **yes**           | **139gp** |
+| 13759     | yes         | yes           | no                | —         |
+
+Only 5312 has a market. Ingredients resolved to 5111.
+
+## Root cause
+
+Both resolution paths in `populate-ingredients.ts` picked arbitrarily:
+
+- `buildItemIdLookupMap` loaded every item `.sort({ _id: 1 })` and kept the **first**
+  occurrence of each name (`if (!map.has(key))`). The duplicate sorts first, so it won.
+- `findItemByDisplayName` used `findOne`, which returns natural order with no preference.
+
+Neither consulted `duplicate`, `placeholder`, `noted` or `tradeable_on_ge`.
+
+`remove-duplicate-items` is not the right layer: it dedupes by numeric `id`, and these
+are genuinely distinct ids representing the same item.
+
+## Scope
+
+Measured against the live `osrsbox` collection:
+
+|                                   |         |
+| --------------------------------- | ------- |
+| Ingredient links inspected        | 28,257  |
+| Pointing at an unpriced duplicate | **735** |
+| Items affected                    | 581     |
+| Distinct ingredient names         | 49      |
+
+Worst by value: Dragon bolts (60 links, real price 3,135gp), Rune kiteshield (32,251gp),
+Adamant kiteshield (3,019gp), Javelin shaft (16 links).
+
+## The fix
+
+`src/lib/helpers/item-preference.ts` ranks candidates by penalty, worst first:
+
+| Fault            | Penalty |
+| ---------------- | ------- |
+| `duplicate`      | 8       |
+| `placeholder`    | 4       |
+| `noted`          | 2       |
+| not GE-tradeable | 1       |
+
+The weights are powers of two so the comparison is lexicographic: no combination of
+lesser faults can outweigh a greater one, and a duplicate is never chosen over a
+canonical document however untradeable that canonical document happens to be. Ties break
+on the lowest in-game id, so the result never depends on storage order.
+
+Absent flags count as "not set" rather than true, so a sparse document is treated as
+canonical instead of being penalised for fields it never had.
+
+Both resolution paths use it, so newly scraped data is correct at the source.
+
+Note the ordering of `noted` above tradeability: a bank note _is_ tradeable, so ranking
+tradeability higher would make notes beat the item they stand for.
+
+## Repairing stored data
+
+```bash
+bun run repair-ingredient-links -- --dry-run
+bun run repair-ingredient-links
+```
+
+The pass moves a link only when the replacement is **strictly** more canonical, so
+equal-ranked links are never reshuffled and repeated runs converge. It is also step
+`ingredient-links` of `bun run update-db`, after `populate-ingredients`; `--skip-ingredient-links`
+opts out.
+
+**Run it after any `populate-ingredients` pass that used the old code**, otherwise that
+scrape reintroduces the bad links.
+
+## Verification performed
+
+- 12 unit tests written before the implementation, modelled on the real Acorn group.
+  They cover order independence, that a note never beats the unnoted item, that a
+  placeholder never beats a real item, and the deterministic id tiebreak.
+- Confirmed against the live dataset that **0 of 8,437** multi-document names lack a
+  non-duplicate candidate, so the ranking always has something canonical to pick.
+  1,126 names remain ambiguous after the flag checks and rely on the id tiebreak.

--- a/scripts/WIKI-NAME-NORMALIZATION.md
+++ b/scripts/WIKI-NAME-NORMALIZATION.md
@@ -1,0 +1,123 @@
+# Wiki name normalization
+
+## The problem
+
+OSRSBox (`osrsreboxed-db`) does not store the real OSRS Wiki page title for items that
+live on a "switch infobox" page. Instead it synthesises `wiki_name` by appending the
+infobox **version label** in parentheses, and points `wiki_url` at an anchor:
+
+| field       | value                                                   |
+| ----------- | ------------------------------------------------------- |
+| `id`        | `5364`                                                  |
+| `name`      | `Oak seedling (w)`  ← real in-game name                 |
+| `wiki_name` | `Oak seedling (Watered)`  ← **synthetic, not a page**   |
+| `wiki_url`  | `.../w/Oak_seedling#Watered`                            |
+
+There is no wiki page called `Oak seedling (Watered)`. The real page is `Oak seedling`,
+and `Watered` is one of its infobox versions.
+
+`scripts/populate-ingredients.ts` derived the wiki page title to scrape from
+`owner.wiki_name ?? owner.name`, so for every one of these items it requested a page
+that does not exist, found no `Creation` section, and left the item with **no
+`creationSpecs`**.
+
+### Scope
+
+Measured against `osrsreboxed-db` `items-complete.json` (28,744 items):
+
+- **8,377** items have an anchored `wiki_url` (~29% of the dataset).
+- **8,266** of those have `wiki_name != name`.
+- For **all 8,377**, `wiki_name` is exactly `"<page title> (<anchor>)"` — the pattern is
+  perfectly consistent, so it can be undone mechanically.
+- `normalizeTitleForLookup()` previously stripped only `(N)` dose suffixes and
+  `(unpoisoned)`, which covers roughly 1,500 of them. The rest silently failed.
+
+Most common version labels: `2 dose`, `1 dose`, `Unpoisoned`, `Normal`, `4 dose`,
+`3 dose`, `Broken`, `Inventory`, `Poison`, `Poison+`, `Poison++`, `Uncharged`,
+`Un-attuned`, `Inactive`, `Charged`, `Locked`, `Worn`, `Attuned`, `Undamaged`,
+`Unpolished`, `Polished`, `Active`, `Empty`, `Watered`, `Unwatered`, …
+
+So this is **not** a seedling-specific problem. Watered seedlings are just the instance
+that surfaced, because saplings sort to the top of the ROI list.
+
+### Why a regex on `wiki_name` is the wrong fix
+
+**4,257** items have a `wiki_name` that legitimately ends in a parenthetical *and* is a
+real page title — `Longbow (u)`, `Oak shortbow (u)`, `Holy grail (item)`, `Ring of
+charos (a)`. Blindly stripping a trailing `(...)` would corrupt all of those.
+
+`wiki_url` is the reliable discriminator. Verified across the whole dataset:
+
+- anchored items where `wiki_name` does **not** start with the URL's page title: **0**
+- items with a `wiki_url` but no `wiki_name`: **0**
+
+So: **if `wiki_url` contains a `#`, the page title is the part before it and the version
+is the part after it.** No guessing, no heuristics.
+
+## The fix
+
+`scripts/lib/wiki-name.ts` derives, from `wiki_url` (authoritative) with a
+`wiki_name`/`name` fallback:
+
+- `wiki_page_title` — the real, fetchable wiki page title (`Oak seedling`)
+- `wiki_version` — the infobox version label, or `null` (`Watered`)
+
+These are persisted as new fields on the item document. `wiki_name` and `wiki_url` are
+left untouched, so nothing that already relies on them changes behaviour, and the
+variant information is preserved rather than thrown away.
+
+Applied in three places so the data cannot drift back:
+
+1. **`scripts/grab-osrsbox-items.ts`** — stamps the fields on every upsert, so a fresh
+   import is correct from the start. (Without this, re-running the import would
+   reintroduce the problem on every update.)
+2. **`scripts/backfill-missing-items.ts`** — same, for items sourced from the price
+   mapping / wiki rather than from OSRSBox.
+3. **`scripts/normalize-wiki-names.ts`** — a standalone, idempotent repair pass over the
+   existing collection, wired into `scripts/update-db.ts` as the `wiki-names` step so it
+   runs before `populate-ingredients`.
+
+`scripts/populate-ingredients.ts` then scrapes `wiki_page_title` instead of `wiki_name`.
+
+## Related, but a separate defect
+
+Fixing the names lets watered seedlings acquire `creationSpecs`. It does **not** on its
+own fix the "saplings show ≤1gp investment / absurd ROI" symptom.
+
+The profit/ROI aggregation in `src/lib/services/game-item-mongo-service.server.ts` prices
+an ingredient as `highPrice ?? lowPrice ?? cost`. A watered seedling is untradeable, so
+it has no `highPrice`/`lowPrice` and falls back to `cost`, which is the game's base value
+of **1**. The pipeline also only descends **one** level (`primarySpec.ingredients`), so
+the acorn that represents the real outlay never enters the sum.
+
+Net effect: `Oak sapling` reports a creation cost of 1gp and an ROI of ~31,600%.
+
+That needs its own change (either treat "untradeable and unpriced" as *unknown* cost
+rather than `cost`, or recurse into the ingredient's own creation tree). Tracked
+separately — see the PR discussion.
+
+## Progress checklist
+
+- [x] Root cause identified and quantified against the full dataset
+- [x] `wiki_url` validated as authoritative (0 counterexamples in 28,744 items)
+- [ ] `scripts/lib/wiki-name.ts` + unit tests
+- [ ] Schema fields `wiki_page_title` / `wiki_version`
+- [ ] `grab-osrsbox-items.ts` stamps derived fields
+- [ ] `backfill-missing-items.ts` stamps derived fields
+- [ ] `normalize-wiki-names.ts` repair script
+- [ ] `update-db.ts` wires in the new step
+- [ ] `populate-ingredients.ts` scrapes `wiki_page_title`
+- [ ] Verified against the live database (**blocked: no `.env` / Mongo credentials**)
+
+## Resuming this work
+
+The analysis above is complete and does not need redoing. Reference data used for the
+measurements can be re-downloaded with:
+
+```bash
+curl -sL -o items-complete.json \
+  https://raw.githubusercontent.com/0xNeffarion/osrsreboxed-db/master/docs/items-complete.json
+```
+
+Branch: `claude/wiki-name-version-suffix-normalization` (based on the profit/ROI branch
+`claude/ge-skiller-profit-roi-ui-3154eh`, which merges to `main` as-is).

--- a/scripts/WIKI-NAME-NORMALIZATION.md
+++ b/scripts/WIKI-NAME-NORMALIZATION.md
@@ -129,12 +129,37 @@ bun run normalize-wiki-names                # write
 It is also step `wiki-names` of `bun run update-db`, so a normal refresh picks it up
 automatically. `--skip-wiki-names` opts out.
 
-After it has run, re-run `populate-ingredients` so the ~8,300 previously unresolvable
-items get their creation trees:
+After it has run, re-scrape the items it unlocked so they get their creation trees:
 
 ```bash
-bun run populate-item-ingredient-trees
+bun run --env-file .env scripts/populate-ingredients.ts --skip-existing --versioned-only
 ```
+
+`--versioned-only` restricts the pass to items carrying a `wiki_version`. Those are
+exactly the ones whose lookups used to fail; everything else was already reachable under
+its own name, so re-scraping it just re-reads pages that were already read successfully
+and found to have no creation method. With `--skip-existing` this is ~7,600 items rather
+than ~22,000 — roughly 3 hours instead of 8 at the observed ~45 requests/minute.
+
+A full refresh is still `bun run populate-item-ingredient-trees`.
+
+## Applied
+
+Run against the `osrsbox` master DB on 2026-08-21. Live results matched the offline
+prediction exactly:
+
+| | Predicted | Actual |
+| --- | --- | --- |
+| Documents written | 28,744 + backfills | **28,763** |
+| Resolve to a different page | 9,209 | **9,209** |
+| Carrying a version anchor | 8,377 | **8,377** |
+
+The 19-document difference is hand-backfilled items, and all 19 landed in the
+no-behaviour-change bucket. A second dry run reported 0 pending writes, confirming
+idempotency. Post-migration integrity across all 28,763 documents: 0 null titles, 0
+empty titles, 0 titles retaining `#`, `_` or percent-escapes.
+
+`osrsbox-dev` and `osrsbox-prod` are untouched pending the re-scrape.
 
 ## Reading the numbers
 

--- a/scripts/WIKI-NAME-NORMALIZATION.md
+++ b/scripts/WIKI-NAME-NORMALIZATION.md
@@ -195,9 +195,12 @@ upload dialog, `find-ingredient-cycles.ts`, the items API — sees byte-identica
 
     The suite skips itself when no such instance is reachable.
 
-## Known unrelated bug this exposes
+## The same bug in the UI
 
-`src/routes/items/[id=integer]/+page.svelte` builds its "view on wiki" link from
-`wiki_name`, so that link 404s for the same 8,377 items. It is a one-line fix — prefer
-the stored `wiki_url`, which already carries the correct anchor — but it is a UI change
-and is deliberately left out of this migration.
+`src/routes/items/[id=integer]/+page.svelte` built its "view on wiki" link by slugifying
+`wiki_name`, so that link 404d for the same 8,377 items. It now uses the stored
+`wiki_url`, which is authoritative and already carries the version anchor, so those
+items land on their own section of the page. `wiki_page_title` is the fallback when no
+URL is stored, and `getGameItemById` projects it so the fallback has a value.
+
+This needs no migration — `wiki_url` was already stored and already correct.

--- a/scripts/WIKI-NAME-NORMALIZATION.md
+++ b/scripts/WIKI-NAME-NORMALIZATION.md
@@ -6,12 +6,12 @@ OSRSBox (`osrsreboxed-db`) does not store the real OSRS Wiki page title for item
 live on a "switch infobox" page. Instead it synthesises `wiki_name` by appending the
 infobox **version label** in parentheses, and points `wiki_url` at an anchor:
 
-| field       | value                                                   |
-| ----------- | ------------------------------------------------------- |
-| `id`        | `5364`                                                  |
-| `name`      | `Oak seedling (w)`  ← real in-game name                 |
-| `wiki_name` | `Oak seedling (Watered)`  ← **synthetic, not a page**   |
-| `wiki_url`  | `.../w/Oak_seedling#Watered`                            |
+| field       | value                                                |
+| ----------- | ---------------------------------------------------- |
+| `id`        | `5364`                                               |
+| `name`      | `Oak seedling (w)` ← real in-game name               |
+| `wiki_name` | `Oak seedling (Watered)` ← **synthetic, not a page** |
+| `wiki_url`  | `.../w/Oak_seedling#Watered`                         |
 
 There is no wiki page called `Oak seedling (Watered)`. The real page is `Oak seedling`,
 and `Watered` is one of its infobox versions.
@@ -42,7 +42,7 @@ that surfaced, because saplings sort to the top of the ROI list.
 
 ### Why a regex on `wiki_name` is the wrong fix
 
-**4,257** items have a `wiki_name` that legitimately ends in a parenthetical *and* is a
+**4,257** items have a `wiki_name` that legitimately ends in a parenthetical _and_ is a
 real page title — `Longbow (u)`, `Oak shortbow (u)`, `Holy grail (item)`, `Ring of
 charos (a)`. Blindly stripping a trailing `(...)` would corrupt all of those.
 
@@ -92,13 +92,13 @@ it has no `highPrice`/`lowPrice` and fell through to `cost` — the game's base 
 which is why saplings dominated the new ROI sort.
 
 `cost` is now used only for ingredients that are actually tradeable on the GE. An
-untradeable ingredient is priced as *unknown*, which nulls the creation cost and keeps
+untradeable ingredient is priced as _unknown_, which nulls the creation cost and keeps
 the item out of the profit and ROI sorts rather than letting it top them on a fabricated
 number. `game-item-creation-cost-table.svelte` applies the same rule client-side, where
 the recursive walk it already does surfaces the real underlying cost on the child rows.
 
 Note the list pipeline still only descends **one** level (`primarySpec.ingredients`), so
-it does not sum an item's full creation tree. Making saplings show their *true* acorn-based
+it does not sum an item's full creation tree. Making saplings show their _true_ acorn-based
 investment (rather than dropping out as unknown) would mean either recursing in the
 aggregation or precomputing an effective value per item offline, in the style of
 `compute-creation-tree-skills.ts`. That is a larger change and is not attempted here.
@@ -136,22 +136,68 @@ items get their creation trees:
 bun run populate-item-ingredient-trees
 ```
 
+## Reading the numbers
+
+Two different counts get quoted about this migration, and confusing them makes the
+change look far bigger than it is.
+
+| Count                                 | Value      | Meaning                                                                                                                 |
+| ------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Documents written                     | **28,744** | Every item. `wiki_page_title` / `wiki_version` are new fields, so every document gains them on the first run.           |
+| Titles that differ from `wiki_name`   | **9,209**  | Items that will now resolve to a _different_ wiki page.                                                                 |
+| ...of which carry a `#version` anchor | **8,377**  | The switch-infobox items — the actual defect.                                                                           |
+| ...of which have no `wiki_url` at all | **832**    | `wiki_name` is null; the derivation falls back to `name`, which is what the old code already used. No behaviour change. |
+| Items untouched entirely              | **0**      | Every item derives _something_.                                                                                         |
+
+So the write count is the whole collection by construction, and it is not a measure of
+impact. Only 9,209 items change behaviour, and only 8,377 of those are the bug. The
+migration adds two fields and never modifies `name`, `wiki_name` or `wiki_url`, so
+anything reading those is unaffected.
+
+`normalize-wiki-names.ts` prints both figures side by side so the write count cannot be
+mistaken for the blast radius.
+
+## Blast radius
+
+`wiki_page_title` / `wiki_version` are read by exactly one consumer:
+`scripts/populate-ingredients.ts`, via `wikiTitleCandidates()`. No route, component or
+service reads them. Everything still reading `wiki_name` — the item detail page, the
+upload dialog, `find-ingredient-cycles.ts`, the items API — sees byte-identical data.
+
 ## Verification performed
 
-- Unit tests: `bun test` (no database required).
-- Whole-dataset replay of the derivation over `items-complete.json`: 8,377 anchored
-  titles corrected, 20,367 non-anchored titles left byte-identical, 0 mangled.
-- Live wiki check over a 30-item spread: the derived title resolves 30/30; the current
-  `wiki_name` resolves 3/30.
+- Unit tests: `bun test` — 16 pass with no database; 19 pass with one.
+- Whole-dataset replay of the derivation over `items-complete.json` (28,744 items):
+  9,209 titles changed, 19,535 left byte-identical, **0 mangled** (every derived title
+  is a prefix of the `wiki_name` it came from).
+- 6,215 derived titles legitimately end in `(...)` — e.g. `Longbow (u)`,
+  `Holy grail (item)`. A regex that stripped trailing parentheses from `wiki_name`
+  would have corrupted all of them. Deriving from `wiki_url` leaves them intact.
+- **Full live-wiki validation** of every distinct page title involved, via the
+  MediaWiki API:
+
+    | Titles                                  | Resolve                    |
+    | --------------------------------------- | -------------------------- |
+    | Derived (`wiki_page_title`)             | **1,329 / 1,330 — 99.92%** |
+    | Old (`wiki_name`, what the scrape used) | **148 / 4,350 — 3.40%**    |
+
+    The single failure is `Kebbit (unobtainable item)`, backing 12 untradeable items
+    whose wiki page has been deleted upstream. Its `wiki_name` 404s too, so this is stale
+    OSRSBox data rather than a regression.
+
 - Aggregation behaviour covered by `src/lib/services/game-item-creation-cost.test.ts`,
   which runs against a real MongoDB:
 
-  ```bash
-  docker run -d --rm -p 27018:27017 mongo:7
-  bun test
-  ```
+    ```bash
+    docker run -d --rm -p 27018:27017 mongo:7
+    bun test
+    ```
 
-  The suite skips itself when no such instance is reachable.
+    The suite skips itself when no such instance is reachable.
 
-**Not verified against the production database** — this workspace has no `.env`, so
-there are no Mongo credentials here. The dry run is the intended first step.
+## Known unrelated bug this exposes
+
+`src/routes/items/[id=integer]/+page.svelte` builds its "view on wiki" link from
+`wiki_name`, so that link 404s for the same 8,377 items. It is a one-line fix — prefer
+the stored `wiki_url`, which already carries the correct anchor — but it is a UI change
+and is deliberately left out of this migration.

--- a/scripts/WIKI-NAME-NORMALIZATION.md
+++ b/scripts/WIKI-NAME-NORMALIZATION.md
@@ -56,7 +56,7 @@ is the part after it.** No guessing, no heuristics.
 
 ## The fix
 
-`scripts/lib/wiki-name.ts` derives, from `wiki_url` (authoritative) with a
+`src/lib/helpers/wiki-page-title.ts` derives, from `wiki_url` (authoritative) with a
 `wiki_name`/`name` fallback:
 
 - `wiki_page_title` — the real, fetchable wiki page title (`Oak seedling`)
@@ -79,45 +79,79 @@ Applied in three places so the data cannot drift back:
 
 `scripts/populate-ingredients.ts` then scrapes `wiki_page_title` instead of `wiki_name`.
 
-## Related, but a separate defect
+## The second defect: untradeable ingredients priced at 1gp
 
-Fixing the names lets watered seedlings acquire `creationSpecs`. It does **not** on its
-own fix the "saplings show ≤1gp investment / absurd ROI" symptom.
+Fixing the names lets watered seedlings acquire `creationSpecs`, but on its own it does
+**not** fix the "saplings show ≤1gp investment / absurd ROI" symptom. That has an
+independent cause, also fixed here.
 
-The profit/ROI aggregation in `src/lib/services/game-item-mongo-service.server.ts` prices
+The profit/ROI aggregation in `src/lib/services/game-item-mongo-service.server.ts` priced
 an ingredient as `highPrice ?? lowPrice ?? cost`. A watered seedling is untradeable, so
-it has no `highPrice`/`lowPrice` and falls back to `cost`, which is the game's base value
-of **1**. The pipeline also only descends **one** level (`primarySpec.ingredients`), so
-the acorn that represents the real outlay never enters the sum.
+it has no `highPrice`/`lowPrice` and fell through to `cost` — the game's base value of
+**1**. `Oak sapling` therefore reported a creation cost of 1gp and an ROI of ~31,500%,
+which is why saplings dominated the new ROI sort.
 
-Net effect: `Oak sapling` reports a creation cost of 1gp and an ROI of ~31,600%.
+`cost` is now used only for ingredients that are actually tradeable on the GE. An
+untradeable ingredient is priced as *unknown*, which nulls the creation cost and keeps
+the item out of the profit and ROI sorts rather than letting it top them on a fabricated
+number. `game-item-creation-cost-table.svelte` applies the same rule client-side, where
+the recursive walk it already does surfaces the real underlying cost on the child rows.
 
-That needs its own change (either treat "untradeable and unpriced" as *unknown* cost
-rather than `cost`, or recurse into the ingredient's own creation tree). Tracked
-separately — see the PR discussion.
+Note the list pipeline still only descends **one** level (`primarySpec.ingredients`), so
+it does not sum an item's full creation tree. Making saplings show their *true* acorn-based
+investment (rather than dropping out as unknown) would mean either recursing in the
+aggregation or precomputing an effective value per item offline, in the style of
+`compute-creation-tree-skills.ts`. That is a larger change and is not attempted here.
 
-## Progress checklist
+## Status
 
 - [x] Root cause identified and quantified against the full dataset
 - [x] `wiki_url` validated as authoritative (0 counterexamples in 28,744 items)
-- [ ] `scripts/lib/wiki-name.ts` + unit tests
-- [ ] Schema fields `wiki_page_title` / `wiki_version`
-- [ ] `grab-osrsbox-items.ts` stamps derived fields
-- [ ] `backfill-missing-items.ts` stamps derived fields
-- [ ] `normalize-wiki-names.ts` repair script
-- [ ] `update-db.ts` wires in the new step
-- [ ] `populate-ingredients.ts` scrapes `wiki_page_title`
-- [ ] Verified against the live database (**blocked: no `.env` / Mongo credentials**)
+- [x] `src/lib/helpers/wiki-page-title.ts` + unit tests
+- [x] Schema fields `wiki_page_title` / `wiki_version`
+- [x] `grab-osrsbox-items.ts` stamps derived fields
+- [x] `backfill-missing-items.ts` stamps derived fields
+- [x] `normalize-wiki-names.ts` repair script
+- [x] `update-db.ts` wires in the `wiki-names` step
+- [x] `populate-ingredients.ts` scrapes the derived title
+- [x] Untradeable ingredients no longer priced from `cost`
+- [ ] **Run against the live database** — see below
 
-## Resuming this work
+## Running it
 
-The analysis above is complete and does not need redoing. Reference data used for the
-measurements can be re-downloaded with:
+The repair pass is idempotent and supports a dry run:
 
 ```bash
-curl -sL -o items-complete.json \
-  https://raw.githubusercontent.com/0xNeffarion/osrsreboxed-db/master/docs/items-complete.json
+bun run normalize-wiki-names -- --dry-run   # report only
+bun run normalize-wiki-names                # write
 ```
 
-Branch: `claude/wiki-name-version-suffix-normalization` (based on the profit/ROI branch
-`claude/ge-skiller-profit-roi-ui-3154eh`, which merges to `main` as-is).
+It is also step `wiki-names` of `bun run update-db`, so a normal refresh picks it up
+automatically. `--skip-wiki-names` opts out.
+
+After it has run, re-run `populate-ingredients` so the ~8,300 previously unresolvable
+items get their creation trees:
+
+```bash
+bun run populate-item-ingredient-trees
+```
+
+## Verification performed
+
+- Unit tests: `bun test` (no database required).
+- Whole-dataset replay of the derivation over `items-complete.json`: 8,377 anchored
+  titles corrected, 20,367 non-anchored titles left byte-identical, 0 mangled.
+- Live wiki check over a 30-item spread: the derived title resolves 30/30; the current
+  `wiki_name` resolves 3/30.
+- Aggregation behaviour covered by `src/lib/services/game-item-creation-cost.test.ts`,
+  which runs against a real MongoDB:
+
+  ```bash
+  docker run -d --rm -p 27018:27017 mongo:7
+  bun test
+  ```
+
+  The suite skips itself when no such instance is reachable.
+
+**Not verified against the production database** — this workspace has no `.env`, so
+there are no Mongo credentials here. The dry run is the intended first step.

--- a/scripts/WIKI-NAME-NORMALIZATION.md
+++ b/scripts/WIKI-NAME-NORMALIZATION.md
@@ -103,6 +103,109 @@ investment (rather than dropping out as unknown) would mean either recursing in 
 aggregation or precomputing an effective value per item offline, in the style of
 `compute-creation-tree-skills.ts`. That is a larger change and is not attempted here.
 
+## The third defect: every variant's recipe stored on every variant
+
+Recovering the page title exposes the next layer. `wiki_url` anchors an item at **one**
+panel of a shared page, but the MediaWiki API cannot serve part of a section — asking for
+`Creation` on `Steel dart` returns all eleven recipes, eight fletching panels and three
+poisoning panels. `populate-ingredients.ts` stored every one of them on every variant.
+
+Both the item page and the profit aggregation take the _first_ spec with ingredients, so
+whichever panel the wiki happens to list first became the item's recipe:
+
+| Item               | Primary spec it was given        | What that recipe actually makes |
+| ------------------ | -------------------------------- | ------------------------------- |
+| `Steel dart(p)`    | 10x Steel dart tip + 10x Feather | unpoisoned darts                |
+| `Steel javelin(p)` | 15x Javelin shaft                | unpoisoned javelins             |
+| `Oak seedling (w)` | Filled plant pot + Acorn         | an _unwatered_ seedling         |
+
+Measured on the live collection: **1,838** versioned items carried more than one spec,
+and the item page rendered each of them as a "Spec N" tab.
+
+`src/lib/helpers/wiki-creation-variants.ts` narrows the scraped methods to the item's own
+version. The wiki labels its switch panels with the same names OSRSBox anchors on, so the
+label is the discriminator, applied in two steps:
+
+1. Panels labelled with the item's own version win outright.
+2. Failing that, panels labelled with a _sibling_ version are dropped. This is what keeps
+   the three poisoning recipes off unpoisoned `Steel bolts`, whose own panels are named
+   for the feather rather than for the version and so never match by name.
+
+Anything the labels cannot account for is kept, and the filter only runs when the page
+scraped is the one this item's own `wiki_url` points at. Sampled over 60 versioned pages
+against the live wiki: **44** item/version pairs narrowed, **127** left alone.
+
+Step 2 can empty the list, and that is an answer rather than a failure. `Abyssal dagger`
+documents only the three poisoning recipes — the plain dagger is a drop, not a craft — so
+it was being handed the cheapest of them and reported a **399gp** creation cost on a 2.2M
+item, which made it the **top result of the live ROI sort**. Items in that position now
+have their inherited specs cleared instead. It only happens when _every_ panel is claimed
+by a named sibling, which across three 70-page samples came to 1–3 pages each: the plain
+variants of `Abyssal dagger`, `Black knife`, `Black spear`, `Dragon knife`, `Dark bow`.
+A page whose labels stop matching keeps everything rather than losing it, so the failure
+mode is "too much", never "too little".
+
+Pages that label by something other than a version are untouched: `Candle lantern`
+("White candle", "Black candle"), `Crystal bow` ("Crafting", "Ilfeen"), and the many
+Creation sections that are plain subsections with no labels at all — `Oak seedling` among
+them.
+
+## The fourth defect: the product row read as an ingredient
+
+Filtering to the right panel made a latent scraper bug visible. The wiki's recipe table
+lists inputs, a `Total cost` row, then the output, then profit rows. The parser instead
+identified the output _by name_: a self-link, an exact title match, or a numeric dose
+variant.
+
+On a variant panel that is exactly backwards. The `Poison` panel of `Adamant dagger` reads
+`Adamant dagger` + `Weapon poison` -> `Adamant dagger(p)`; the input is the self-link and
+the output links away to its own redirect page. The parser called `Adamant dagger(p)` an
+ingredient — leaving the poisoned dagger an ingredient of itself — and the base dagger the
+product.
+
+`parseMaterialsAndInlineProducts` now splits on the `Total cost` row the template already
+provides, falling back to the old name-based rule for tables that have none. Compared
+old-vs-new over 130 sampled pages against the live wiki: **119 identical, 11 changed, and
+every change a correction** —
+
+- `Dragon knife(p)` = 5x Dragon knife + Weapon poison, instead of listing itself.
+- `Granite maul (clamp)` = Granite maul + Granite clamp, instead of the reverse.
+- `Soft clay` no longer charges for the Bucket it _returns_ to you.
+- `Guthix max cape` correctly produces both the cape and the hood.
+
+Belt and braces, `mapWikiMethodToCreationSpecs` now refuses to store an item as its own
+ingredient. On a page whose variants share one name — watered and unwatered
+`Oak seedling` — the input resolves straight back to the owner, and no amount of parser
+accuracy can separate them.
+
+## Currency is not an untradeable ingredient
+
+The "untradeable ingredients are priced as unknown" rule above is right about materials
+and wrong about money. `Coins` carries `tradeable_on_ge: false` — you cannot list coins on
+the Grand Exchange — but a recipe that charges 5 coins costs 5gp, and **3,257** of the
+9,824 items with recipes charge a coin fee. Pricing coins as unknown nulled the creation
+cost for a third of the catalogue and dropped all of it out of the profit and ROI sorts.
+
+`src/lib/helpers/ingredient-price.ts` now holds the single rule both the aggregation and
+the item page apply: GE price first, then `cost` — but only for an item that is GE
+tradeable or _is_ money (`Coins`, `Platinum token`). Simulated over the whole live
+collection, that takes the number of items whose cost becomes unknown from **4,497** down
+to **2,282**, and the remainder are genuinely ungettable-for-gp inputs: `Bone in vinegar`,
+`Lovakite ore`, `Crystal shard`, `Max cape`.
+
+## Unknown ingredient prices no longer read as free
+
+`game-item-creation-cost-table.svelte` skipped rows whose price was unknown when summing,
+which counted them as 0gp and inflated every profit line below the table. That is harmless
+only when the walk has already expanded the row into the child rows carrying the real
+outlay — an `Oak seedling (w)` that resolves to its acorn — and wrong when it has not,
+which is exactly the case the untradeable rule creates.
+
+Rows now record whether they were substituted by a child recipe. An unowned row with no
+price and no substitute makes the total, and every profit line, report unknown rather than
+a number that is too good. The aggregation already behaved this way (`costKnown`), so this
+brings the item page into line with the list.
+
 ## Status
 
 - [x] Root cause identified and quantified against the full dataset
@@ -115,7 +218,14 @@ aggregation or precomputing an effective value per item offline, in the style of
 - [x] `update-db.ts` wires in the `wiki-names` step
 - [x] `populate-ingredients.ts` scrapes the derived title
 - [x] Untradeable ingredients no longer priced from `cost`
-- [ ] **Run against the live database** — see below
+- [x] Currency exempted from that rule
+- [x] Scraped methods narrowed to the item's own infobox version
+- [x] Specs cleared from variants their page documents no recipe for
+- [x] `populate-ingredients.ts --dry-run`
+- [x] Recipe tables split on `Total cost` instead of guessing the product by name
+- [x] Cost table reports an unknown total instead of counting it as free
+- [x] Wiki-title migration run against `osrsbox` and `osrsbox-dev`
+- [ ] **Re-scrape and promote to `osrsbox-prod`** — see below
 
 ## Running it
 
@@ -143,16 +253,28 @@ than ~22,000 — roughly 3 hours instead of 8 at the observed ~45 requests/minut
 
 A full refresh is still `bun run populate-item-ingredient-trees`.
 
+The re-scrape overwrites `creationSpecs` wholesale, so preview it first — `--dry-run`
+scrapes and maps exactly as usual but reports the before/after spec count per item without
+touching a document:
+
+```bash
+bun run --env-file .env scripts/populate-ingredients.ts --dry-run --versioned-only
+```
+
+Note that the variant and product fixes above change what a re-scrape produces for items
+that already have specs, so `--skip-existing` no longer covers the whole job: the 1,838
+versioned items holding a sibling variant's recipe need a refresh, not a skip.
+
 ## Applied
 
 Run against the `osrsbox` master DB on 2026-08-21. Live results matched the offline
 prediction exactly:
 
-| | Predicted | Actual |
-| --- | --- | --- |
-| Documents written | 28,744 + backfills | **28,763** |
-| Resolve to a different page | 9,209 | **9,209** |
-| Carrying a version anchor | 8,377 | **8,377** |
+|                             | Predicted          | Actual     |
+| --------------------------- | ------------------ | ---------- |
+| Documents written           | 28,744 + backfills | **28,763** |
+| Resolve to a different page | 9,209              | **9,209**  |
+| Carrying a version anchor   | 8,377              | **8,377**  |
 
 The 19-document difference is hand-backfilled items, and all 19 landed in the
 no-behaviour-change bucket. A second dry run reported 0 pending writes, confirming
@@ -184,10 +306,11 @@ mistaken for the blast radius.
 
 ## Blast radius
 
-`wiki_page_title` / `wiki_version` are read by exactly one consumer:
-`scripts/populate-ingredients.ts`, via `wikiTitleCandidates()`. No route, component or
-service reads them. Everything still reading `wiki_name` — the item detail page, the
-upload dialog, `find-ingredient-cycles.ts`, the items API — sees byte-identical data.
+`wiki_page_title` and `wiki_version` are read by `scripts/populate-ingredients.ts` — the
+title via `wikiTitleCandidates()`, the version via `selectMethodsForVersion()` — and the
+title once more as a link fallback on the item detail page. Everything still reading
+`wiki_name` — the upload dialog, `find-ingredient-cycles.ts`, the items API — sees
+byte-identical data.
 
 ## Verification performed
 

--- a/scripts/backfill-missing-items.ts
+++ b/scripts/backfill-missing-items.ts
@@ -13,6 +13,7 @@
 import mongoose from 'mongoose';
 import * as cheerio from 'cheerio';
 import { OsrsboxItemModel } from '../src/lib/models/mongo-schemas/osrsbox-db-item-schema';
+import { deriveWikiPageIdentity } from '../src/lib/helpers/wiki-page-title';
 
 /**
  * ======================================================================
@@ -783,7 +784,13 @@ async function main() {
             // 4. Merge latest GE prices
             const finalItem = mergeItemWithPrices(baseItem, latestPrices);
 
-            // 5. Upsert via your osrsboxItemSchema
+            // 5. Record the real wiki page title, so later wiki scrapes don't have to
+            // guess at OSRSBox's synthetic "<page> (<version>)" wiki_name.
+            const { wikiPageTitle, wikiVersion } = deriveWikiPageIdentity(finalItem);
+            finalItem.wiki_page_title = wikiPageTitle;
+            finalItem.wiki_version = wikiVersion;
+
+            // 6. Upsert via your osrsboxItemSchema
             await OsrsboxItemModel.updateOne({ id: finalItem.id }, { $set: finalItem }, { upsert: true });
 
             imported.push(rawName);

--- a/scripts/grab-osrsbox-items.ts
+++ b/scripts/grab-osrsbox-items.ts
@@ -7,6 +7,7 @@ import consola from 'consola';
 import logUpdate from 'log-update';
 import { OsrsboxItemModel } from '../src/lib/models/mongo-schemas/osrsbox-db-item-schema';
 import type { IOsrsboxItem } from '../src/lib/models/osrsbox-db-item';
+import { deriveWikiPageIdentity } from '../src/lib/helpers/wiki-page-title';
 
 /**
  * ====================================================================================================================
@@ -149,10 +150,20 @@ async function upsertGameItems(
         // Preserve any existing creationSpecs by never updating them from this source.
         const { creationSpecs, ...itemWithoutCreationSpecs } = item;
 
+        // OSRSBox has no field for the real wiki page title, so derive it on the way in.
+        // Doing it here (rather than only in a repair pass) keeps re-imports correct.
+        const { wikiPageTitle, wikiVersion } = deriveWikiPageIdentity(item);
+
         const update: {
             $set: typeof itemWithoutCreationSpecs;
             $setOnInsert?: { creationSpecs: IOsrsboxItem['creationSpecs'] };
-        } = { $set: itemWithoutCreationSpecs };
+        } = {
+            $set: {
+                ...itemWithoutCreationSpecs,
+                wiki_page_title: wikiPageTitle,
+                wiki_version: wikiVersion,
+            },
+        };
 
         if (creationSpecs !== undefined) {
             update.$setOnInsert = { creationSpecs };

--- a/scripts/normalize-wiki-names.ts
+++ b/scripts/normalize-wiki-names.ts
@@ -44,11 +44,31 @@ type WikiFields = {
     wiki_version?: string | null;
 };
 
+/** Outcome counters for a normalization run. */
+type NormalizeReport = {
+    scanned: number;
+    /** Documents whose stored fields differ from the derived ones, so they get written. */
+    changed: number;
+    /** Documents actually modified (always 0 on a dry run). */
+    written: number;
+    /**
+     * Of `changed`, the documents where the derived title differs from `wiki_name`.
+     *
+     * This is the number that matters: it is the count of items whose wiki lookups
+     * actually behave differently afterwards. The rest are simply having two brand-new
+     * fields populated for the first time with a value the old code already used, which
+     * is why `changed` is ~the entire collection on the first run.
+     */
+    behaviourChanged: number;
+    /** Documents carrying an infobox version label. */
+    versioned: number;
+};
+
 /**
  * Rewrites `wiki_page_title` / `wiki_version` for every item that needs it.
- * @returns Counts of the documents scanned, changed and written.
+ * @returns Counters describing what the run scanned, changed and wrote.
  */
-async function normalizeWikiNames(): Promise<{ scanned: number; changed: number; written: number }> {
+async function normalizeWikiNames(): Promise<NormalizeReport> {
     const cursor = OsrsboxItemModel.find(
         {},
         { _id: 1, id: 1, name: 1, wiki_name: 1, wiki_url: 1, wiki_page_title: 1, wiki_version: 1 },
@@ -60,6 +80,7 @@ async function normalizeWikiNames(): Promise<{ scanned: number; changed: number;
     let changed = 0;
     let written = 0;
     let versioned = 0;
+    let behaviourChanged = 0;
     let operations: mongoose.AnyBulkWriteOperation[] = [];
     const samples: string[] = [];
 
@@ -84,6 +105,10 @@ async function normalizeWikiNames(): Promise<{ scanned: number; changed: number;
 
         changed += 1;
 
+        // Distinguish "field is being populated for the first time" from "this item will
+        // now resolve to a different wiki page". Only the latter changes any behaviour.
+        if (wikiPageTitle !== (doc.wiki_name ?? null)) behaviourChanged += 1;
+
         // Surface a few real corrections so a dry run is actually informative.
         if (samples.length < 15 && wikiVersion && wikiPageTitle !== doc.wiki_name) {
             samples.push(`  id=${doc.id} "${doc.wiki_name}" -> "${wikiPageTitle}" (version: ${wikiVersion})`);
@@ -104,9 +129,8 @@ async function normalizeWikiNames(): Promise<{ scanned: number; changed: number;
     if (samples.length) {
         logger.info(`Example corrections:\n${samples.join('\n')}`);
     }
-    logger.info(`${versioned} item(s) carry an infobox version label.`);
 
-    return { scanned, changed, written };
+    return { scanned, changed, written, behaviourChanged, versioned };
 }
 
 (async function main() {
@@ -117,12 +141,28 @@ async function normalizeWikiNames(): Promise<{ scanned: number; changed: number;
         await mongoose.connect(connectionString, { dbName });
         logger.success('Connection established.');
 
-        const { scanned, changed, written } = await normalizeWikiNames();
+        const report = await normalizeWikiNames();
+        const { scanned, changed, written, behaviourChanged, versioned } = report;
+
+        // Report both numbers explicitly. On a first run `changed` is essentially the whole
+        // collection, because `wiki_page_title` / `wiki_version` do not exist yet and every
+        // document gains them. That figure looks alarming on its own and says nothing about
+        // impact, so the behavioural count is spelled out next to it.
+        const unchangedTitles = changed - behaviourChanged;
+        logger.info(
+            [
+                `Scanned ................................. ${scanned}`,
+                `Documents ${DRY_RUN ? 'that would be written' : 'written'} ......... ${DRY_RUN ? changed : written}`,
+                `  - new fields only, same title ......... ${unchangedTitles}  (no behaviour change)`,
+                `  - resolve to a different wiki page .... ${behaviourChanged}  (the actual fix)`,
+                `Items carrying an infobox version ....... ${versioned}`,
+            ].join('\n'),
+        );
 
         logger.success(
             DRY_RUN
-                ? `Dry run complete | scanned=${scanned} would-update=${changed}`
-                : `Normalization complete | scanned=${scanned} changed=${changed} written=${written}`,
+                ? `Dry run complete | scanned=${scanned} would-write=${changed} behaviour-change=${behaviourChanged}`
+                : `Normalization complete | scanned=${scanned} written=${written} behaviour-change=${behaviourChanged}`,
         );
     } catch (error) {
         logger.error(`Error in script: ${error}`);

--- a/scripts/normalize-wiki-names.ts
+++ b/scripts/normalize-wiki-names.ts
@@ -1,0 +1,134 @@
+// normalize-wiki-names.ts
+//
+// Repairs `wiki_page_title` / `wiki_version` across the whole items collection.
+//
+// OSRSBox has no field for the real wiki page title. For items that live on a
+// "switch infobox" page it synthesises `wiki_name` as "<page title> (<version>)" and
+// anchors `wiki_url` at the version — e.g. "Oak seedling (Watered)" pointing at
+// ".../w/Oak_seedling#Watered". There is no page by that name, so any scrape keyed on
+// `wiki_name` 404s. Around 8,300 of ~28,700 items are affected.
+//
+// This pass derives the real title from `wiki_url` and stores it alongside the
+// original fields, which are left untouched. It is idempotent: running it twice is a
+// no-op, and it only writes documents whose derived values actually differ.
+//
+// Run with:
+//   bun run normalize-wiki-names
+//   bun run normalize-wiki-names -- --dry-run
+
+import mongoose from 'mongoose';
+import consola from 'consola';
+import { OsrsboxItemModel } from '../src/lib/models/mongo-schemas/osrsbox-db-item-schema';
+import { deriveWikiPageIdentity } from '../src/lib/helpers/wiki-page-title';
+
+const logger = consola.create({ defaults: { tag: 'normalize-wiki-names' } });
+
+const user = process.env.VITE_MONGO_USERNAME;
+const pw = process.env.VITE_MONGO_PASSWORD;
+const cluster = process.env.VITE_MONGO_DB_CLUSTER_NAME;
+const host = process.env.VITE_MONGO_DB_HOST;
+const dbName = process.env.VITE_MONGO_DB_DB_NAME || 'osrsbox';
+const connectionString = `mongodb+srv://${user}:${pw}@${cluster}.${host}/${dbName}?retryWrites=true&w=majority`;
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const BATCH_SIZE = 1_000;
+
+type WikiFields = {
+    _id: mongoose.Types.ObjectId;
+    id?: number;
+    name?: string | null;
+    wiki_name?: string | null;
+    wiki_url?: string | null;
+    wiki_page_title?: string | null;
+    wiki_version?: string | null;
+};
+
+/**
+ * Rewrites `wiki_page_title` / `wiki_version` for every item that needs it.
+ * @returns Counts of the documents scanned, changed and written.
+ */
+async function normalizeWikiNames(): Promise<{ scanned: number; changed: number; written: number }> {
+    const cursor = OsrsboxItemModel.find(
+        {},
+        { _id: 1, id: 1, name: 1, wiki_name: 1, wiki_url: 1, wiki_page_title: 1, wiki_version: 1 },
+    )
+        .lean<WikiFields[]>()
+        .cursor();
+
+    let scanned = 0;
+    let changed = 0;
+    let written = 0;
+    let versioned = 0;
+    let operations: mongoose.AnyBulkWriteOperation[] = [];
+    const samples: string[] = [];
+
+    const flush = async () => {
+        if (!operations.length) return;
+        if (!DRY_RUN) {
+            const result = await OsrsboxItemModel.bulkWrite(operations, { ordered: false });
+            written += result.modifiedCount;
+        }
+        operations = [];
+    };
+
+    for await (const doc of cursor) {
+        scanned += 1;
+
+        const { wikiPageTitle, wikiVersion } = deriveWikiPageIdentity(doc);
+        if (wikiVersion) versioned += 1;
+
+        const alreadyCorrect =
+            (doc.wiki_page_title ?? null) === wikiPageTitle && (doc.wiki_version ?? null) === wikiVersion;
+        if (alreadyCorrect) continue;
+
+        changed += 1;
+
+        // Surface a few real corrections so a dry run is actually informative.
+        if (samples.length < 15 && wikiVersion && wikiPageTitle !== doc.wiki_name) {
+            samples.push(`  id=${doc.id} "${doc.wiki_name}" -> "${wikiPageTitle}" (version: ${wikiVersion})`);
+        }
+
+        operations.push({
+            updateOne: {
+                filter: { _id: doc._id },
+                update: { $set: { wiki_page_title: wikiPageTitle, wiki_version: wikiVersion } },
+            },
+        });
+
+        if (operations.length >= BATCH_SIZE) await flush();
+    }
+
+    await flush();
+
+    if (samples.length) {
+        logger.info(`Example corrections:\n${samples.join('\n')}`);
+    }
+    logger.info(`${versioned} item(s) carry an infobox version label.`);
+
+    return { scanned, changed, written };
+}
+
+(async function main() {
+    if (DRY_RUN) logger.info('Dry run — no writes will be performed.');
+
+    try {
+        logger.info(`Connecting to MongoDB (db: ${dbName})...`);
+        await mongoose.connect(connectionString, { dbName });
+        logger.success('Connection established.');
+
+        const { scanned, changed, written } = await normalizeWikiNames();
+
+        logger.success(
+            DRY_RUN
+                ? `Dry run complete | scanned=${scanned} would-update=${changed}`
+                : `Normalization complete | scanned=${scanned} changed=${changed} written=${written}`,
+        );
+    } catch (error) {
+        logger.error(`Error in script: ${error}`);
+        process.exitCode = 1;
+    } finally {
+        await mongoose.disconnect();
+        logger.info('MongoDB connection closed.');
+    }
+})();

--- a/scripts/osrs-wiki-creation.ts
+++ b/scripts/osrs-wiki-creation.ts
@@ -406,8 +406,17 @@ function parseRequirementsTable($: cheerio.CheerioAPI, $table: cheerio.Cheerio):
  *   - second column: item link
  *   - third column: quantity
  *   - fourth column: cost
- * And which may also contain the *product* row (selflink to current page)
- * plus Total cost / Profit rows.
+ * And which may also contain the *product* row plus Total cost / Profit rows.
+ *
+ * The wiki's recipe template lays the rows out as inputs, then a `Total cost` header row,
+ * then the output, then Profit rows — so that header is what separates the two, and it is
+ * the only signal that survives a variant panel. Name-based detection cannot: on the
+ * "Poison" panel of `Adamant dagger` the *input* is the selflink `Adamant dagger` and the
+ * *output* is `Adamant dagger(p)`, which links away to its own redirect page. Reading
+ * those by name got the recipe exactly backwards, leaving the poisoned dagger listed as
+ * an ingredient of itself.
+ *
+ * Tables with no `Total cost` row fall back to the original name-based rule.
  */
 function parseMaterialsAndInlineProducts(
     $: cheerio.CheerioAPI,
@@ -420,6 +429,18 @@ function parseMaterialsAndInlineProducts(
     const $rows = $table.find('tr');
     if ($rows.length === 0) return { materials, products };
 
+    const isTotalCostRow = ($row: cheerio.Cheerio): boolean => {
+        const firstCell = $row.find('td, th').first();
+        return firstCell.is('th') && /total cost/.test(firstCell.text().toLowerCase().trim());
+    };
+
+    let hasTotalCostRow = false;
+    $rows.slice(1).each((_, row) => {
+        if (isTotalCostRow($(row))) hasTotalCostRow = true;
+    });
+
+    let pastTotalCost = false;
+
     $rows.slice(1).each((_, row) => {
         const $row = $(row);
         const $cells = $row.find('td, th');
@@ -431,6 +452,7 @@ function parseMaterialsAndInlineProducts(
         if (firstCell.is('th')) {
             const headerText = firstCell.text().toLowerCase().trim();
             if (/total cost|profit after ge tax|profit/.test(headerText) && headerText.length > 0) {
+                if (/total cost/.test(headerText)) pastTotalCost = true;
                 return;
             }
         }
@@ -492,12 +514,15 @@ function parseMaterialsAndInlineProducts(
             isNumericParenVariant = /^\(\d+(?:\s*\/\s*\d+)?\)$/.test(remainder);
         }
 
-        // Treat as product if:
+        // Position wins where the template provides it: everything above `Total cost` is an
+        // input and everything below it is an output, whatever the rows are named.
+        // Otherwise treat as product if:
         // - it's the selflink (same page), OR
         // - exact match, OR
         // - it's a numeric dose/charge variant like "prayer potion(3)" or "ring of recoil (8)"
-        const isProductRow =
-            selfLink.length > 0 || nameLower === titleLower || (isNumericParenVariant && !isUnstrungVariant);
+        const isProductRow = hasTotalCostRow
+            ? pastTotalCost
+            : selfLink.length > 0 || nameLower === titleLower || (isNumericParenVariant && !isUnstrungVariant);
 
         if (isProductRow) {
             products.push({

--- a/scripts/populate-ingredients.ts
+++ b/scripts/populate-ingredients.ts
@@ -542,24 +542,41 @@ function extractSkillRequirements(wikiReqs: WikiRequirement[]): {
     return { requiredSkills, experienceGranted };
 }
 
+/** A mapped method, plus why it should be discarded. */
+type MappedCreationMethod = {
+    specs: GameItemCreationSpecs;
+    /**
+     * The method consumes the owner, so it makes something else.
+     *
+     * A page with one unlabelled recipe hands that recipe to every variant on it.
+     * `Torva full helm` documents only the restoration — damaged helm + Bandosian
+     * components — so the *damaged* helm was given a recipe that in fact destroys it, and
+     * with the self-reference dropped that read as "9M of components produce a 223M item".
+     * Nothing in OSRS is built from itself, so a method that takes the owner as input
+     * belongs to a sibling variant and is discarded whole rather than trimmed.
+     */
+    consumesOwner: boolean;
+};
+
 async function mapWikiMethodToCreationSpecs(
     wikiMethod: WikiCreationMethod,
     owner: OsrsboxItemDocument,
     cache: Map<string, mongoose.Types.ObjectId>,
-): Promise<GameItemCreationSpecs> {
+): Promise<MappedCreationMethod> {
     const { requiredSkills, experienceGranted } = extractSkillRequirements(wikiMethod.requirements);
 
     const ingredients: GameItemCreationIngredient[] = [];
+    let consumesOwner = false;
 
     // 1) Normal materials (consumed = true/false based on wiki data)
     for (const m of wikiMethod.materials) {
         const { itemId, ignored } = await resolveItemIdForName(m.item.name, owner, cache);
         if (ignored || !itemId) continue;
-        // Nothing is an ingredient of itself. A variant panel lists the base item as its
-        // input ("Adamant dagger" + "Weapon poison" -> "Adamant dagger(p)"), and where the
-        // variants share one name — watered and unwatered "Oak seedling" — that input
-        // resolves straight back to the owner.
-        if (itemId.equals(owner._id)) continue;
+
+        if (itemId.equals(owner._id)) {
+            consumesOwner = true;
+            continue;
+        }
 
         ingredients.push({
             consumedDuringCreation: m.consumed,
@@ -596,9 +613,8 @@ async function mapWikiMethodToCreationSpecs(
     }
 
     return {
-        requiredSkills,
-        experienceGranted,
-        ingredients,
+        specs: { requiredSkills, experienceGranted, ingredients },
+        consumesOwner,
     };
 }
 
@@ -717,9 +733,19 @@ export async function importCreationForItemTitle(identifier: string, options: Im
 
     const cache = new Map<string, mongoose.Types.ObjectId>();
     const creationSpecs: GameItemCreationSpecs[] = [];
+    let discardedConsumingOwner = 0;
 
     for (const m of variantMethods) {
-        const specs = await mapWikiMethodToCreationSpecs(m, owner, cache);
+        const { specs, consumesOwner } = await mapWikiMethodToCreationSpecs(m, owner, cache);
+
+        if (consumesOwner) {
+            discardedConsumingOwner += 1;
+            logWithProgress(
+                'log',
+                `[creation-importer] Dropping a method for "${owner.name}" that consumes it (methodName="${m.methodName}"); it belongs to another variant of "${resolvedTitle}".`,
+            );
+            continue;
+        }
 
         // If a method has no skills and no ingredients, it's probably junk – skip it.
         const hasSkills = specs.requiredSkills.length > 0 || specs.experienceGranted.length > 0;
@@ -737,6 +763,14 @@ export async function importCreationForItemTitle(identifier: string, options: Im
     }
 
     if (!creationSpecs.length) {
+        // Nothing survived, and what was dropped was dropped because it makes a sibling
+        // rather than this item. That is the same finding as the version filter reaching
+        // zero, so it clears inherited specs for the same reason.
+        if (discardedConsumingOwner) {
+            await clearCreationSpecsForOtherVariant(owner, resolvedTitle, options);
+            return;
+        }
+
         logWithProgress(
             'warn',
             `[creation-importer] No valid creationSpecs built for "${identifier}" after filtering.`,

--- a/scripts/populate-ingredients.ts
+++ b/scripts/populate-ingredients.ts
@@ -14,6 +14,7 @@ import type {
     GameItemCreationIngredient,
     SkillLevelDesignation,
 } from '../src/lib/models/osrsbox-db-item';
+import { wikiTitleCandidates } from '../src/lib/helpers/wiki-page-title';
 
 /**
  * ====================================================================================================================
@@ -217,6 +218,35 @@ function normalizeTitleForLookup(title: string): string {
     }
 
     return normalized;
+}
+
+/**
+ * Ordered wiki page titles to try for an item, most reliable first.
+ *
+ * `wikiTitleCandidates` supplies the derived page title, the in-game name and the raw
+ * `wiki_name`; each is also offered in its dose-stripped form, and the CLI identifier
+ * is kept as a last resort when it isn't just an ObjectId.
+ * @param owner - The item whose creation page is being scraped.
+ * @param identifier - The identifier the importer was invoked with.
+ * @returns Deduplicated candidate page titles.
+ */
+function buildWikiLookupTitles(owner: OsrsboxItemDocument, identifier: string): string[] {
+    const raw = wikiTitleCandidates(owner);
+    if (identifier && !looksLikeObjectId(identifier)) raw.push(identifier);
+
+    const seen = new Set<string>();
+    const titles: string[] = [];
+
+    for (const candidate of raw) {
+        for (const title of [candidate, normalizeTitleForLookup(candidate)]) {
+            const trimmed = title.trim();
+            if (!trimmed || seen.has(trimmed.toLowerCase())) continue;
+            seen.add(trimmed.toLowerCase());
+            titles.push(trimmed);
+        }
+    }
+
+    return titles;
 }
 
 function escapeRegex(value: string): string {
@@ -555,29 +585,34 @@ export async function importCreationForItemTitle(identifier: string, options: Im
         return;
     }
 
-    // Decide what title to use for the wiki: prefer wiki_name, then name
-    const baseTitle = owner.wiki_name ?? owner.name;
-    const normalizedTitle = normalizeTitleForLookup(baseTitle);
+    // Decide what titles to try on the wiki. The derived page title comes first:
+    // OSRSBox's wiki_name is synthetic for versioned items ("Oak seedling (Watered)")
+    // and 404s, so trusting it here used to leave ~8,300 items without creationSpecs.
+    const lookupTitles = buildWikiLookupTitles(owner, identifier);
+    const baseTitle = lookupTitles[0] ?? owner.name;
 
-    // Try normalized wiki title first (e.g. strip dose), then fall back to raw
-    let wikiMethods = await getCreationMethodsForItem(normalizedTitle);
+    let wikiMethods: WikiCreationMethod[] = [];
+    let resolvedTitle = baseTitle;
 
-    if (!wikiMethods.length && normalizedTitle !== baseTitle) {
-        wikiMethods = await getCreationMethodsForItem(baseTitle);
-    }
-
-    // As a final fallback, if the CLI identifier differs from baseTitle, try that too
-    if (!wikiMethods.length && identifier !== baseTitle && identifier !== normalizedTitle) {
-        wikiMethods = await getCreationMethodsForItem(identifier);
+    for (const title of lookupTitles) {
+        wikiMethods = await getCreationMethodsForItem(title);
+        if (wikiMethods.length) {
+            resolvedTitle = title;
+            break;
+        }
     }
 
     if (!wikiMethods.length) {
         logWithProgress(
             'warn',
-            `⚠️ [creation-importer] No creation methods from wiki for "${normalizedTitle}" (base="${baseTitle}", identifier="${identifier}")`,
+            `⚠️ [creation-importer] No creation methods from wiki for "${baseTitle}" (tried: ${lookupTitles.join(' | ')}, identifier="${identifier}")`,
         );
-        logNoWikiMethods(owner, identifier, normalizedTitle);
+        logNoWikiMethods(owner, identifier, baseTitle);
         return;
+    }
+
+    if (resolvedTitle !== baseTitle) {
+        logWithProgress('log', `[creation-importer] Resolved "${baseTitle}" via fallback title "${resolvedTitle}"`);
     }
 
     const cache = new Map<string, mongoose.Types.ObjectId>();

--- a/scripts/populate-ingredients.ts
+++ b/scripts/populate-ingredients.ts
@@ -357,6 +357,16 @@ type ImportOptions = {
      * Only process items whose name or wiki_name contains this string (case-insensitive).
      */
     nameContains?: string;
+    /**
+     * Only process items that carry an infobox version label (`wiki_version`).
+     *
+     * These are the items whose wiki lookups used to fail, because OSRSBox's `wiki_name`
+     * is synthetic for them. Everything else was already reachable under its own name, so
+     * a re-scrape of those items re-fetches pages that were read successfully before and
+     * found to have no creation method. Narrowing to versioned items turns a full pass
+     * over ~22,000 items into ~7,700.
+     */
+    versionedOnly?: boolean;
 };
 
 /**
@@ -697,6 +707,10 @@ export async function importCreationForAllItems(options: ImportOptions = {}): Pr
         baseFilter.$or = [{ creationSpecs: { $exists: false } }, { creationSpecs: { $size: 0 } }];
     }
 
+    if (options.versionedOnly) {
+        baseFilter.wiki_version = { $ne: null };
+    }
+
     if (options.nameContains) {
         const needle = options.nameContains.trim();
         if (needle) {
@@ -816,6 +830,7 @@ export async function importCreationForAllItems(options: ImportOptions = {}): Pr
 async function main() {
     const args = process.argv.slice(2);
     let skipExisting = false;
+    let versionedOnly = false;
     let resumeFromId: string | undefined;
     let nameContains: string | undefined;
     const positionalArgs: string[] = [];
@@ -829,6 +844,11 @@ async function main() {
 
         if (arg === '--skip-existing') {
             skipExisting = true;
+            continue;
+        }
+
+        if (arg === '--versioned-only') {
+            versionedOnly = true;
             continue;
         }
 
@@ -899,8 +919,14 @@ async function main() {
                     `[creation-importer] Limiting batch to items whose name/wiki_name contains "${nameContains.trim()}".`,
                 );
             }
+            if (versionedOnly) {
+                logWithProgress(
+                    'log',
+                    '[creation-importer] Limiting batch to items with an infobox version (--versioned-only).',
+                );
+            }
             logWithProgress('log', '[creation-importer] Running in batch mode over all items...');
-            await importCreationForAllItems({ skipExisting, resumeFromId, nameContains });
+            await importCreationForAllItems({ skipExisting, resumeFromId, nameContains, versionedOnly });
         } else {
             logWithProgress('log', `[creation-importer] Importing creation specs for "${arg}"...`);
             await importCreationForItemTitle(arg, { skipExisting });

--- a/scripts/populate-ingredients.ts
+++ b/scripts/populate-ingredients.ts
@@ -15,6 +15,7 @@ import type {
     SkillLevelDesignation,
 } from '../src/lib/models/osrsbox-db-item';
 import { wikiTitleCandidates } from '../src/lib/helpers/wiki-page-title';
+import { pickPreferredItem } from '../src/lib/helpers/item-preference';
 
 /**
  * ====================================================================================================================
@@ -322,23 +323,44 @@ function normalizeLookupKey(value: string): string {
 }
 
 async function buildItemIdLookupMap(): Promise<Map<string, mongoose.Types.ObjectId>> {
-    const map = new Map<string, mongoose.Types.ObjectId>();
-    const docs = await OsrsboxItemModel.find({}, { _id: 1, name: 1, wiki_name: 1 })
+    type LookupDoc = {
+        _id: mongoose.Types.ObjectId;
+        id?: number;
+        name?: string;
+        wiki_name?: string;
+        duplicate?: boolean;
+        placeholder?: boolean;
+        noted?: boolean;
+        tradeable_on_ge?: boolean;
+    };
+
+    const docs = await OsrsboxItemModel.find(
+        {},
+        { _id: 1, id: 1, name: 1, wiki_name: 1, duplicate: 1, placeholder: 1, noted: 1, tradeable_on_ge: 1 },
+    )
         .sort({ _id: 1 })
-        .lean<{ _id: mongoose.Types.ObjectId; name?: string; wiki_name?: string }[]>()
+        .lean<LookupDoc[]>()
         .exec();
     recordAtlasRequest();
 
+    // Thousands of names are shared by several documents — "Acorn" covers four duplicate
+    // ids, the real tradeable item and a bank placeholder. Keeping whichever arrived
+    // first handed ingredients an unpriced duplicate, so rank the candidates instead.
+    const best = new Map<string, LookupDoc>();
+
+    const consider = (key: string, doc: LookupDoc) => {
+        const current = best.get(key);
+        const winner = current ? pickPreferredItem([current, doc]) : doc;
+        if (winner) best.set(key, winner);
+    };
+
     for (const doc of docs) {
-        if (doc.name) {
-            const key = normalizeLookupKey(doc.name);
-            if (!map.has(key)) map.set(key, doc._id);
-        }
-        if (doc.wiki_name) {
-            const key = normalizeLookupKey(doc.wiki_name);
-            if (!map.has(key)) map.set(key, doc._id);
-        }
+        if (doc.name) consider(normalizeLookupKey(doc.name), doc);
+        if (doc.wiki_name) consider(normalizeLookupKey(doc.wiki_name), doc);
     }
+
+    const map = new Map<string, mongoose.Types.ObjectId>();
+    for (const [key, doc] of best) map.set(key, doc._id);
 
     return map;
 }
@@ -375,25 +397,20 @@ type ImportOptions = {
 async function findItemByDisplayName(name: string): Promise<OsrsboxItemDocument | null> {
     const trimmed = name.trim();
 
-    // 1) Exact wiki_name
-    let doc = await OsrsboxItemModel.findOne({ wiki_name: trimmed }).exec();
-    if (doc) return doc;
+    // Each tier may match several documents sharing the name, so gather them all and let
+    // the ranking decide. `findOne` used to return whichever the database stored first,
+    // which for a name like "Acorn" is an unpriced duplicate rather than the real item.
+    const tiers: mongoose.FilterQuery<OsrsboxItemDocument>[] = [
+        { wiki_name: trimmed },
+        { name: trimmed },
+        { wiki_name: { $regex: new RegExp(`^${escapeRegex(trimmed)}$`, 'i') } },
+        { name: { $regex: new RegExp(`^${escapeRegex(trimmed)}$`, 'i') } },
+    ];
 
-    // 2) Exact in-game name
-    doc = await OsrsboxItemModel.findOne({ name: trimmed }).exec();
-    if (doc) return doc;
-
-    // 3) Case-insensitive wiki_name
-    doc = await OsrsboxItemModel.findOne({
-        wiki_name: { $regex: new RegExp(`^${escapeRegex(trimmed)}$`, 'i') },
-    }).exec();
-    if (doc) return doc;
-
-    // 4) Case-insensitive name
-    doc = await OsrsboxItemModel.findOne({
-        name: { $regex: new RegExp(`^${escapeRegex(trimmed)}$`, 'i') },
-    }).exec();
-    if (doc) return doc;
+    for (const filter of tiers) {
+        const docs = await OsrsboxItemModel.find(filter).exec();
+        if (docs.length) return pickPreferredItem(docs);
+    }
 
     return null;
 }

--- a/scripts/populate-ingredients.ts
+++ b/scripts/populate-ingredients.ts
@@ -14,7 +14,8 @@ import type {
     GameItemCreationIngredient,
     SkillLevelDesignation,
 } from '../src/lib/models/osrsbox-db-item';
-import { wikiTitleCandidates } from '../src/lib/helpers/wiki-page-title';
+import { deriveWikiPageIdentity, wikiTitleCandidates } from '../src/lib/helpers/wiki-page-title';
+import { selectMethodsForVersion } from '../src/lib/helpers/wiki-creation-variants';
 
 /**
  * ====================================================================================================================
@@ -41,6 +42,7 @@ const progressState = {
     recentRequests: [] as number[],
 };
 let itemIdLookupMap: Map<string, mongoose.Types.ObjectId> | null = null;
+const wikiPageVersionCache = new Map<string, string[]>();
 let isShuttingDown = false;
 const originalConsole = {
     log: console.log.bind(console),
@@ -249,6 +251,32 @@ function buildWikiLookupTitles(owner: OsrsboxItemDocument, identifier: string): 
     return titles;
 }
 
+/**
+ * The infobox versions of every item that shares a wiki page, cached per page title.
+ *
+ * `selectMethodsForVersion` needs these to tell "this panel belongs to another variant"
+ * apart from "this panel is labelled by something that isn't a variant at all". There
+ * are only ~540 versioned pages behind ~8,400 items, so the cache keeps this to one
+ * `distinct` per page for a whole batch run.
+ * @param pageTitle - The derived wiki page title shared by the variants.
+ * @returns Every non-null `wiki_version` recorded against that page.
+ */
+async function getVersionsForWikiPage(pageTitle: string | null | undefined): Promise<string[]> {
+    if (!pageTitle) return [];
+
+    const cached = wikiPageVersionCache.get(pageTitle);
+    if (cached) return cached;
+
+    recordAtlasRequest();
+    const versions = (await OsrsboxItemModel.distinct('wiki_version', {
+        wiki_page_title: pageTitle,
+        wiki_version: { $ne: null },
+    })) as string[];
+
+    wikiPageVersionCache.set(pageTitle, versions);
+    return versions;
+}
+
 function escapeRegex(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -367,6 +395,14 @@ type ImportOptions = {
      * over ~22,000 items into ~7,700.
      */
     versionedOnly?: boolean;
+    /**
+     * Scrape and map exactly as usual, but report what would be written instead of writing.
+     *
+     * This step overwrites `creationSpecs` wholesale, so a run against a populated database
+     * is worth previewing: the log then shows the before/after spec count per item without
+     * touching a document.
+     */
+    dryRun?: boolean;
 };
 
 /**
@@ -502,6 +538,11 @@ async function mapWikiMethodToCreationSpecs(
     for (const m of wikiMethod.materials) {
         const { itemId, ignored } = await resolveItemIdForName(m.item.name, owner, cache);
         if (ignored || !itemId) continue;
+        // Nothing is an ingredient of itself. A variant panel lists the base item as its
+        // input ("Adamant dagger" + "Weapon poison" -> "Adamant dagger(p)"), and where the
+        // variants share one name — watered and unwatered "Oak seedling" — that input
+        // resolves straight back to the owner.
+        if (itemId.equals(owner._id)) continue;
 
         ingredients.push({
             consumedDuringCreation: m.consumed,
@@ -527,6 +568,7 @@ async function mapWikiMethodToCreationSpecs(
         for (const toolName of toolNames) {
             const { itemId, ignored } = await resolveItemIdForName(toolName, owner, cache);
             if (ignored || !itemId) continue;
+            if (itemId.equals(owner._id)) continue;
 
             ingredients.push({
                 consumedDuringCreation: false,
@@ -625,10 +667,41 @@ export async function importCreationForItemTitle(identifier: string, options: Im
         logWithProgress('log', `[creation-importer] Resolved "${baseTitle}" via fallback title "${resolvedTitle}"`);
     }
 
+    // A versioned item's URL anchors it at one panel of a shared page, but the wiki API
+    // only serves whole sections, so `wikiMethods` holds every variant's recipe. Storing
+    // all of them hands the item a primary spec belonging to whichever variant the wiki
+    // lists first. Only narrow when the page actually came from this item's own
+    // `wiki_url` — a fallback title is a different page, and its panel labels say
+    // nothing about this item's version.
+    const derivedPageTitle = deriveWikiPageIdentity(owner).wikiPageTitle;
+    const scrapedOwnPage = !!derivedPageTitle && resolvedTitle.toLowerCase() === derivedPageTitle.toLowerCase();
+    // Sibling lookup is a collection scan, so it is only worth paying for an item that has
+    // a version to compare them against.
+    const variantMethods =
+        scrapedOwnPage && owner.wiki_version
+            ? selectMethodsForVersion(wikiMethods, owner.wiki_version, await getVersionsForWikiPage(derivedPageTitle))
+            : wikiMethods;
+
+    if (variantMethods.length !== wikiMethods.length) {
+        logWithProgress(
+            'log',
+            `[creation-importer] Narrowed "${resolvedTitle}" from ${wikiMethods.length} to ${variantMethods.length} method(s) for version "${owner.wiki_version}".`,
+        );
+    }
+
+    // Every method on the page belongs to a named sibling, so this variant is not made
+    // here at all — the plain "Abyssal dagger" is a drop, and the page only documents
+    // poisoning. Any specs it is carrying came from a sibling and have to go, otherwise
+    // the item keeps costing itself at a poison vial.
+    if (!variantMethods.length) {
+        await clearCreationSpecsForOtherVariant(owner, resolvedTitle, options);
+        return;
+    }
+
     const cache = new Map<string, mongoose.Types.ObjectId>();
     const creationSpecs: GameItemCreationSpecs[] = [];
 
-    for (const m of wikiMethods) {
+    for (const m of variantMethods) {
         const specs = await mapWikiMethodToCreationSpecs(m, owner, cache);
 
         // If a method has no skills and no ingredients, it's probably junk – skip it.
@@ -657,6 +730,16 @@ export async function importCreationForItemTitle(identifier: string, options: Im
 
     const hadExistingSpecs = owner.creationSpecs?.length ?? 0;
 
+    if (options.dryRun) {
+        logWithProgress(
+            'log',
+            `🔍 [creation-importer] Would write ${creationSpecs.length} creation spec(s) over ${hadExistingSpecs} for "${
+                owner.wiki_name ?? owner.name
+            }" (dry run).`,
+        );
+        return;
+    }
+
     owner.creationSpecs = creationSpecs;
     await owner.save();
 
@@ -667,6 +750,41 @@ export async function importCreationForItemTitle(identifier: string, options: Im
         `✅ [creation-importer] ${action} ${creationSpecs.length} creation spec(s) for "${
             owner.wiki_name ?? owner.name
         }".`,
+    );
+}
+
+/**
+ * Drops creation specs from an item whose wiki page documents no recipe for its variant.
+ *
+ * Returning early instead would leave the sibling's recipe in place forever, because this
+ * importer only ever overwrites `creationSpecs` and never clears them.
+ * @param owner - The item being imported.
+ * @param pageTitle - The page that was scraped, for the log line.
+ * @param options - Import options; `dryRun` reports instead of writing.
+ */
+async function clearCreationSpecsForOtherVariant(
+    owner: OsrsboxItemDocument,
+    pageTitle: string,
+    options: ImportOptions,
+): Promise<void> {
+    const existing = owner.creationSpecs?.length ?? 0;
+
+    if (!existing) return;
+
+    if (options.dryRun) {
+        logWithProgress(
+            'log',
+            `🔍 [creation-importer] Would clear ${existing} creation spec(s) from "${owner.name}": "${pageTitle}" documents no recipe for version "${owner.wiki_version}" (dry run).`,
+        );
+        return;
+    }
+
+    owner.creationSpecs = [];
+    await owner.save();
+
+    logWithProgress(
+        'log',
+        `🧹 [creation-importer] Cleared ${existing} creation spec(s) from "${owner.name}": "${pageTitle}" documents no recipe for version "${owner.wiki_version}".`,
     );
 }
 
@@ -831,6 +949,7 @@ async function main() {
     const args = process.argv.slice(2);
     let skipExisting = false;
     let versionedOnly = false;
+    let dryRun = false;
     let resumeFromId: string | undefined;
     let nameContains: string | undefined;
     const positionalArgs: string[] = [];
@@ -849,6 +968,11 @@ async function main() {
 
         if (arg === '--versioned-only') {
             versionedOnly = true;
+            continue;
+        }
+
+        if (arg === '--dry-run') {
+            dryRun = true;
             continue;
         }
 
@@ -925,11 +1049,14 @@ async function main() {
                     '[creation-importer] Limiting batch to items with an infobox version (--versioned-only).',
                 );
             }
+            if (dryRun) {
+                logWithProgress('log', '[creation-importer] Dry run: nothing will be written.');
+            }
             logWithProgress('log', '[creation-importer] Running in batch mode over all items...');
-            await importCreationForAllItems({ skipExisting, resumeFromId, nameContains, versionedOnly });
+            await importCreationForAllItems({ skipExisting, resumeFromId, nameContains, versionedOnly, dryRun });
         } else {
             logWithProgress('log', `[creation-importer] Importing creation specs for "${arg}"...`);
-            await importCreationForItemTitle(arg, { skipExisting });
+            await importCreationForItemTitle(arg, { skipExisting, dryRun });
         }
     } catch (err) {
         logWithProgress('error', '🚨 [creation-importer] Unhandled error:', err);

--- a/scripts/repair-ingredient-links.ts
+++ b/scripts/repair-ingredient-links.ts
@@ -1,0 +1,206 @@
+// repair-ingredient-links.ts
+//
+// Repoints ingredient references at the canonical document for their item.
+//
+// The OSRSBox dataset stores one document per in-game item id, and a name can cover
+// many ids. "Acorn" is ids 5111-5114 (all flagged `duplicate`, no GE market), the real
+// tradeable item 5312, and a bank placeholder 13759. Ingredient resolution used to take
+// whichever document the database returned first, so creationSpecs ended up pointing at
+// unpriced duplicates and anything built from them looked free.
+//
+// `populate-ingredients` now ranks candidates via `pickPreferredItem`, so newly scraped
+// data is correct. This pass fixes links already stored.
+//
+// It only moves a link when the replacement is strictly more canonical, so it is
+// idempotent and never reshuffles links that are merely tied.
+//
+// Run with:
+//   bun run repair-ingredient-links
+//   bun run repair-ingredient-links -- --dry-run
+
+import mongoose from 'mongoose';
+import consola from 'consola';
+import { OsrsboxItemModel } from '../src/lib/models/mongo-schemas/osrsbox-db-item-schema';
+import { itemPreferenceRank, pickPreferredItem } from '../src/lib/helpers/item-preference';
+
+const logger = consola.create({ defaults: { tag: 'repair-ingredient-links' } });
+
+const user = process.env.VITE_MONGO_USERNAME;
+const pw = process.env.VITE_MONGO_PASSWORD;
+const cluster = process.env.VITE_MONGO_DB_CLUSTER_NAME;
+const host = process.env.VITE_MONGO_DB_HOST;
+const dbName = process.env.VITE_MONGO_DB_DB_NAME || 'osrsbox';
+const connectionString = `mongodb+srv://${user}:${pw}@${cluster}.${host}/${dbName}?retryWrites=true&w=majority`;
+
+const DRY_RUN = process.argv.slice(2).includes('--dry-run');
+const BATCH_SIZE = 500;
+
+/** One ingredient reference inside a creation spec. */
+type IngredientLink = {
+    item?: mongoose.Types.ObjectId | null;
+    [key: string]: unknown;
+};
+
+/**
+ * A creation spec as read back for repair. Only `ingredients` is touched; the index
+ * signature carries the other fields (experience, skills, tree metadata) through the
+ * rewrite untouched.
+ */
+type CreationSpecLike = {
+    ingredients?: IngredientLink[];
+    [key: string]: unknown;
+};
+
+type CatalogDoc = {
+    _id: mongoose.Types.ObjectId;
+    id?: number;
+    name?: string;
+    duplicate?: boolean;
+    placeholder?: boolean;
+    noted?: boolean;
+    tradeable_on_ge?: boolean;
+};
+
+/**
+ * Loads every item once, indexed for lookup by `_id` and grouped by name.
+ * @returns The per-document index and the name groups used to pick a canonical item.
+ */
+async function loadCatalog() {
+    const docs = await OsrsboxItemModel.find(
+        {},
+        { _id: 1, id: 1, name: 1, duplicate: 1, placeholder: 1, noted: 1, tradeable_on_ge: 1 },
+    )
+        .lean<CatalogDoc[]>()
+        .exec();
+
+    const byId = new Map<string, CatalogDoc>();
+    const byName = new Map<string, CatalogDoc[]>();
+
+    for (const doc of docs) {
+        byId.set(doc._id.toString(), doc);
+        if (!doc.name) continue;
+        const key = doc.name.trim().toLowerCase();
+        const group = byName.get(key);
+        if (group) group.push(doc);
+        else byName.set(key, [doc]);
+    }
+
+    return { byId, byName, total: docs.length };
+}
+
+/**
+ * Rewrites ingredient references that point at a less canonical document than exists.
+ * @returns Counts describing what was scanned, changed and written.
+ */
+async function repairIngredientLinks() {
+    const { byId, byName, total } = await loadCatalog();
+    logger.info(`Catalog loaded: ${total} documents, ${byName.size} distinct names.`);
+
+    const cursor = OsrsboxItemModel.find(
+        { 'creationSpecs.0': { $exists: true } },
+        { _id: 1, name: 1, creationSpecs: 1 },
+    )
+        .lean<{ _id: mongoose.Types.ObjectId; name?: string; creationSpecs?: CreationSpecLike[] }[]>()
+        .cursor();
+
+    let scanned = 0;
+    let linksSeen = 0;
+    let linksMoved = 0;
+    let itemsChanged = 0;
+    let written = 0;
+    let operations: mongoose.AnyBulkWriteOperation[] = [];
+    const samples: string[] = [];
+
+    const flush = async () => {
+        if (!operations.length) return;
+        if (!DRY_RUN) {
+            const result = await OsrsboxItemModel.bulkWrite(operations, { ordered: false });
+            written += result.modifiedCount;
+        }
+        operations = [];
+    };
+
+    for await (const doc of cursor) {
+        scanned += 1;
+        let changed = false;
+
+        for (const spec of doc.creationSpecs ?? []) {
+            for (const ingredient of spec.ingredients ?? []) {
+                const currentId = ingredient?.item;
+                if (!currentId) continue;
+                linksSeen += 1;
+
+                const current = byId.get(currentId.toString());
+                if (!current?.name) continue;
+
+                const group = byName.get(current.name.trim().toLowerCase());
+                if (!group || group.length < 2) continue;
+
+                const preferred = pickPreferredItem(group);
+                if (!preferred) continue;
+
+                // Only move the link when the replacement is genuinely better. Equal ranks
+                // are left alone so repeated runs converge instead of trading places.
+                if (itemPreferenceRank(preferred) >= itemPreferenceRank(current)) continue;
+
+                if (samples.length < 15) {
+                    samples.push(
+                        `  "${doc.name}" ingredient "${current.name}": id=${current.id} (dup=${current.duplicate === true}, ge=${current.tradeable_on_ge === true}) -> id=${preferred.id} (ge=${preferred.tradeable_on_ge === true})`,
+                    );
+                }
+
+                ingredient.item = preferred._id;
+                linksMoved += 1;
+                changed = true;
+            }
+        }
+
+        if (!changed) continue;
+
+        itemsChanged += 1;
+        operations.push({
+            updateOne: { filter: { _id: doc._id }, update: { $set: { creationSpecs: doc.creationSpecs } } },
+        });
+
+        if (operations.length >= BATCH_SIZE) await flush();
+    }
+
+    await flush();
+
+    if (samples.length) logger.info(`Example repairs:\n${samples.join('\n')}`);
+
+    return { scanned, linksSeen, linksMoved, itemsChanged, written };
+}
+
+(async function main() {
+    if (DRY_RUN) logger.info('Dry run — no writes will be performed.');
+
+    try {
+        logger.info(`Connecting to MongoDB (db: ${dbName})...`);
+        await mongoose.connect(connectionString, { dbName });
+        logger.success('Connection established.');
+
+        const { scanned, linksSeen, linksMoved, itemsChanged, written } = await repairIngredientLinks();
+
+        logger.info(
+            [
+                `Items with creation specs .......... ${scanned}`,
+                `Ingredient links inspected ......... ${linksSeen}`,
+                `Links repointed to canonical ....... ${linksMoved}`,
+                `Items ${DRY_RUN ? 'that would be written' : 'written'} ............. ${DRY_RUN ? itemsChanged : written}`,
+            ].join('\n'),
+        );
+
+        logger.success(
+            DRY_RUN
+                ? `Dry run complete | links-to-move=${linksMoved} items-to-write=${itemsChanged}`
+                : `Repair complete | links-moved=${linksMoved} items-written=${written}`,
+        );
+    } catch (error) {
+        logger.error(`Error in script: ${error}`);
+        process.exitCode = 1;
+    } finally {
+        await mongoose.disconnect();
+        logger.info('MongoDB connection closed.');
+    }
+})();

--- a/scripts/rescrape-creation-specs.ts
+++ b/scripts/rescrape-creation-specs.ts
@@ -1,0 +1,187 @@
+// rescrape-creation-specs.ts
+//
+// Runs the full creation-spec rebuild and reports on the result.
+//
+// The wiki scrape is normally reached through `update-db`, which also re-imports the
+// OSRSBox dataset and recomputes tree skills. This runner is the narrower job: rebuild
+// `creationSpecs` from the wiki, repoint the ingredient links, and say whether the
+// outcome looks sound. It exists because the scrape now produces materially different
+// data than the specs already in the database, so a re-run is a migration rather than a
+// refresh:
+//
+//   - methods are narrowed to the item's own infobox version, instead of every variant
+//     on the page landing on every variant of the item
+//   - recipe tables split on the `Total cost` row, so the product row stops being read
+//     as an ingredient
+//   - nothing is stored as its own ingredient
+//
+// A full pass is ~22,000 items and several hours; the wiki is the bottleneck, and a dry
+// run costs the same because the expense is the scraping, not the write. `--versioned-only`
+// is the ~8,400-item subset carrying an infobox version, which is where the corrections
+// above almost all land.
+//
+// Run with:
+//   bun run rescrape-creation-specs                      # full pass on the master DB
+//   bun run rescrape-creation-specs -- --versioned-only  # the versioned subset only
+//   bun run rescrape-creation-specs -- --dry-run         # report, write nothing
+//   bun run rescrape-creation-specs -- --db=osrsbox-dev
+//   bun run rescrape-creation-specs -- --resume-from=<objectid>
+//   bun run rescrape-creation-specs -- --verify-only     # skip the scrape, just report
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import mongoose from 'mongoose';
+
+const args = process.argv.slice(2);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const dbName =
+    args.find((arg) => arg.startsWith('--db='))?.split('=')[1] || process.env.VITE_MONGO_DB_DB_NAME || 'osrsbox';
+const dryRun = args.includes('--dry-run');
+const versionedOnly = args.includes('--versioned-only');
+const verifyOnly = args.includes('--verify-only');
+const resumeFrom = args.find((arg) => arg.startsWith('--resume-from='))?.split('=')[1];
+
+const user = process.env.VITE_MONGO_USERNAME;
+const pw = process.env.VITE_MONGO_PASSWORD;
+const cluster = process.env.VITE_MONGO_DB_CLUSTER_NAME;
+const host = process.env.VITE_MONGO_DB_HOST;
+
+/**
+ * Runs one script as a child process with the target database pinned.
+ *
+ * Each step connects to Mongo itself, so pinning happens through the environment rather
+ * than a shared connection.
+ * @param name - Label for the log line.
+ * @param script - Path to the script, relative to the repo root.
+ * @param scriptArgs - Arguments to forward.
+ */
+async function runStep(name: string, script: string, scriptArgs: string[]): Promise<void> {
+    console.log(`\n[rescrape] ── ${name} ${scriptArgs.join(' ')}`);
+
+    const proc = Bun.spawn({
+        cmd: ['bun', 'run', script, ...scriptArgs],
+        cwd: repoRoot,
+        env: { ...process.env, VITE_MONGO_DB_DB_NAME: dbName },
+        stdout: 'inherit',
+        stderr: 'inherit',
+    });
+
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) throw new Error(`[rescrape] ${name} failed with exit code ${exitCode}.`);
+}
+
+/**
+ * Counts the defects the rescrape is meant to remove.
+ *
+ * Read-only, so it is worth running before and after to see the delta. Multi-spec
+ * versioned items should fall a long way and self-references should reach zero; neither
+ * is expected to be exactly zero for unversioned items, which legitimately have several
+ * recipes.
+ * @returns The measured counts.
+ */
+async function verify(): Promise<Record<string, number>> {
+    const connectionString = `mongodb+srv://${user}:${pw}@${cluster}.${host}/${dbName}?retryWrites=true&w=majority`;
+    await mongoose.connect(connectionString, { dbName });
+
+    try {
+        const items = mongoose.connection.db!.collection('items');
+
+        const [total, withSpecs, versionedMultiSpec, selfReferential] = await Promise.all([
+            items.countDocuments({}),
+            items.countDocuments({ 'creationSpecs.0': { $exists: true } }),
+            items.countDocuments({ wiki_version: { $ne: null }, 'creationSpecs.1': { $exists: true } }),
+            items
+                .aggregate([
+                    { $match: { 'creationSpecs.0': { $exists: true } } },
+                    {
+                        $project: {
+                            self: {
+                                $filter: {
+                                    input: {
+                                        $reduce: {
+                                            input: '$creationSpecs.ingredients',
+                                            initialValue: [],
+                                            in: { $concatArrays: ['$$value', { $ifNull: ['$$this', []] }] },
+                                        },
+                                    },
+                                    as: 'ingredient',
+                                    cond: { $eq: ['$$ingredient.item', '$_id'] },
+                                },
+                            },
+                        },
+                    },
+                    { $match: { 'self.0': { $exists: true } } },
+                    { $count: 'n' },
+                ])
+                .toArray()
+                .then((rows) => (rows[0]?.n as number) ?? 0),
+        ]);
+
+        return { total, withSpecs, versionedMultiSpec, selfReferential };
+    } finally {
+        await mongoose.disconnect();
+    }
+}
+
+/**
+ * Prints a labelled count block.
+ * @param label - Heading for the block.
+ * @param counts - The counts to print.
+ */
+function report(label: string, counts: Record<string, number>): void {
+    console.log(
+        [
+            `\n[rescrape] ${label}`,
+            `  Items ............................... ${counts.total}`,
+            `  With creation specs ................. ${counts.withSpecs}`,
+            `  Versioned items with >1 spec ........ ${counts.versionedMultiSpec}`,
+            `  Items listing themselves ............ ${counts.selfReferential}`,
+        ].join('\n'),
+    );
+}
+
+async function main() {
+    if (!user || !pw || !cluster || !host) {
+        console.error('[rescrape] Missing MongoDB env vars.');
+        process.exit(1);
+    }
+
+    console.log(`[rescrape] Target DB: ${dbName}`);
+    if (dryRun) console.log('[rescrape] Dry run — nothing will be written.');
+    if (versionedOnly) console.log('[rescrape] Scoped to items carrying an infobox version.');
+
+    report('Before', await verify());
+
+    if (!verifyOnly) {
+        const scrapeArgs = ['--all'];
+        if (dryRun) scrapeArgs.push('--dry-run');
+        if (versionedOnly) scrapeArgs.push('--versioned-only');
+        if (resumeFrom) scrapeArgs.push(`--resume-from=${resumeFrom}`);
+
+        await runStep('populate-ingredients', 'scripts/populate-ingredients.ts', scrapeArgs);
+
+        // The scrape writes fresh ingredient links, so the canonical repair runs after it
+        // rather than before.
+        await runStep('repair-ingredient-links', 'scripts/repair-ingredient-links.ts', dryRun ? ['--dry-run'] : []);
+    }
+
+    report('After', await verify());
+
+    console.log(
+        [
+            '\n[rescrape] Next steps are deliberately not automated:',
+            '  - find-ingredient-cycles removes whole creationSpecs entries to break a cycle.',
+            '    Run it with --dry-run and read the report before letting it write.',
+            '  - compute-creation-tree-skills recomputes the per-item skill ranges.',
+            '  - promotion is copy-osrsbox-to-dev, then copy-osrsbox-dev-to-prod.',
+            '    Follow the prod copy with update-item-prices: the copy replaces the',
+            '    collection wholesale and prod carries fresher prices than the master DB.',
+        ].join('\n'),
+    );
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/update-db.ts
+++ b/scripts/update-db.ts
@@ -107,6 +107,13 @@ const steps: Step[] = [
         cmd: ['bun', 'run', 'scripts/remove-duplicate-items.ts'],
     },
     {
+        // Must run before populate-ingredients: that step scrapes the wiki by page
+        // title, and OSRSBox's wiki_name is not a real page title for versioned items.
+        key: 'wiki-names',
+        name: 'normalize-wiki-names',
+        cmd: ['bun', 'run', 'scripts/normalize-wiki-names.ts'],
+    },
+    {
         key: 'ingredients',
         name: 'populate-ingredients',
         cmd: ['bun', 'run', 'scripts/populate-ingredients.ts'],

--- a/scripts/update-db.ts
+++ b/scripts/update-db.ts
@@ -119,6 +119,14 @@ const steps: Step[] = [
         cmd: ['bun', 'run', 'scripts/populate-ingredients.ts'],
     },
     {
+        // Runs after populate-ingredients so any links it wrote are checked too. Newly
+        // scraped data already picks the canonical document; this repairs older rows
+        // that point at an unpriced duplicate.
+        key: 'ingredient-links',
+        name: 'repair-ingredient-links',
+        cmd: ['bun', 'run', 'scripts/repair-ingredient-links.ts'],
+    },
+    {
         key: 'cycles',
         name: 'remove-cyclic-ingredients',
         cmd: ['bun', 'run', 'scripts/find-ingredient-cycles.ts'],

--- a/src/lib/components/dialogs/character-stats-dialog.svelte
+++ b/src/lib/components/dialogs/character-stats-dialog.svelte
@@ -9,7 +9,9 @@
     import SkillsGrid from '$lib/components/global/skills-grid.svelte';
     import { toast } from 'svelte-sonner';
     import * as Dialog from '$lib/components/ui/dialog';
+    import AccountTypeSelect from '$lib/components/global/account-type-select.svelte';
     import { CharacterProfile } from '$lib/models/player-stats';
+    import type { AccountType } from '$lib/models/account-type';
     import { getStoreRoot, getCharacters } from '$lib/stores/character-store.svelte';
     import { fetchCharacterDetailsFromWOM } from '$lib/services/wise-old-man-service';
 
@@ -67,7 +69,7 @@
     const populatedStats = writable(new CharacterProfile(''));
 
     function cloneProfile(profile: CharacterProfile) {
-        return new CharacterProfile(profile.name, { ...profile.skillLevels }, profile.id);
+        return new CharacterProfile(profile.name, { ...profile.skillLevels }, profile.id, profile.accountType);
     }
 
     // Controls whether the buttons in the footer are disabled.
@@ -89,7 +91,11 @@
 
         if (indexOfThisCharacter !== -1) {
             const next = [...currentCharactersList];
-            next[indexOfThisCharacter] = { ...next[indexOfThisCharacter], skillLevels: buffer.skillLevels };
+            next[indexOfThisCharacter] = {
+                ...next[indexOfThisCharacter],
+                accountType: buffer.accountType,
+                skillLevels: buffer.skillLevels,
+            };
             characterStore.characters = next;
         } else {
             characterStore.characters = [...currentCharactersList, buffer];
@@ -116,6 +122,9 @@
 
         try {
             const character = await fetchCharacterDetailsFromWOM($populatedStats.name);
+            // Wise Old Man reports levels, not game mode, so preserve the account type the user
+            // picked rather than letting the import reset it to the constructor default.
+            character.accountType = $populatedStats.accountType;
             populatedStats.set(cloneProfile(character));
             importedName.set(character.name);
         } catch (e) {
@@ -124,6 +133,14 @@
         } finally {
             isLoading.set(false);
         }
+    }
+
+    function handleAccountTypeChange(next: AccountType) {
+        populatedStats.update((current) => {
+            const clone = cloneProfile(current);
+            clone.accountType = next;
+            return clone;
+        });
     }
 
     function handleSkillChange(skill: keyof CharacterProfile['skillLevels'], value: number) {
@@ -157,6 +174,11 @@
                     <Label class="capitalize text-xs" for="character-name">Character name</Label>
                     <Input id="character-name" type="text" required aria-required bind:value={$populatedStats.name} />
                 </div>
+                <AccountTypeSelect
+                    value={$populatedStats.accountType}
+                    onChange={handleAccountTypeChange}
+                    idPrefix="character-dialog"
+                />
                 <SkillsGrid
                     skillLevels={$populatedStats.skillLevels}
                     idPrefix="character-dialog"

--- a/src/lib/components/game-item-creation-card/game-item-creation-cost-table.svelte
+++ b/src/lib/components/game-item-creation-card/game-item-creation-cost-table.svelte
@@ -170,7 +170,12 @@
 
     function resolveUnitPrice(item?: IOsrsboxItemWithMeta | null): number | null {
         if (!item) return null;
-        const price = item.highPrice ?? item.lowPrice ?? item.cost ?? null;
+        // `cost` is the base game value, not a market price. For an item with no GE
+        // market (an untradeable intermediate like "Oak seedling (w)", cost 1) it is
+        // not what the player pays, so the price is reported as unknown and the real
+        // outlay shows up on the child rows this walk already expands to.
+        const fallback = item.tradeable_on_ge ? (item.cost ?? null) : null;
+        const price = item.highPrice ?? item.lowPrice ?? fallback;
         return typeof price === 'number' ? price : null;
     }
 

--- a/src/lib/components/game-item-creation-card/game-item-creation-cost-table.svelte
+++ b/src/lib/components/game-item-creation-card/game-item-creation-cost-table.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import * as Table from '$lib/components/ui/table';
     import { getPrimaryCreationSpec } from '$lib/helpers/creation-specs';
+    import { resolveIngredientUnitPrice } from '$lib/helpers/ingredient-price';
     import type { GameItemCreationSpecs, IOsrsboxItemWithMeta } from '$lib/models/osrsbox-db-item';
     import { bankItemsStore, ensureSuppliesForCharacter, getSuppliesForCharacter } from '$lib/stores/bank-items-store';
     import { getStoreRoot } from '$lib/stores/character-store.svelte';
@@ -20,6 +21,8 @@
         amount: number;
         unitPrice: number | null;
         totalPrice: number | null;
+        /** Whether this walk expanded the row into the child rows that carry its real cost. */
+        substituted: boolean;
     };
 
     const rootSpec = $derived(creationSpec ?? getPrimaryCreationSpec(gameItem) ?? null);
@@ -75,12 +78,27 @@
 
     const allChecked = $derived(Object.values(ownedMap).every(Boolean));
 
-    const selectedTotal = $derived(
-        costRows.reduce((sum, row) => {
-            if (ownedMap[row.key] || row.totalPrice === null) return sum;
-            return sum + row.totalPrice;
-        }, 0),
-    );
+    const selectedTotal = $derived.by(() => {
+        let sum = 0;
+
+        for (const row of costRows) {
+            if (ownedMap[row.key]) continue;
+
+            if (row.totalPrice === null) {
+                // An untradeable ingredient has no price of its own. Skipping it is only
+                // harmless because this walk already expanded it into the child rows that
+                // carry the real outlay. With no such rows — no stored recipe, or a cycle
+                // cut the walk short — the cost genuinely isn't known, and counting the
+                // row as free would report a total, and a profit, that is too good.
+                if (row.substituted) continue;
+                return null;
+            }
+
+            sum += row.totalPrice;
+        }
+
+        return sum;
+    });
 
     const geValue = $derived(normalizeNumber(gameItem?.highPrice ?? gameItem?.lowPrice));
     const storeValue = $derived(normalizeNumber(gameItem?.cost));
@@ -128,20 +146,24 @@
                         ? existing.totalPrice + totalPrice!
                         : (existing.totalPrice ?? totalPrice);
             } else {
-                map.set(key, { key, item, amount, unitPrice, totalPrice });
+                map.set(key, { key, item, amount, unitPrice, totalPrice, substituted: false });
             }
 
             const childId = item.id ?? null;
-            if (childId !== null) {
-                if (visited.has(childId)) continue;
-                visited.add(childId);
-            }
+            if (childId !== null && visited.has(childId)) continue;
 
             const childSpec = getPrimaryCreationSpec(item);
-            if (childSpec) {
-                accumulate(childSpec, amount, map, visited);
-            }
+            const childConsumes = (childSpec?.ingredients ?? []).some(
+                (child) => child?.item && child.consumedDuringCreation !== false,
+            );
+            if (!childSpec || !childConsumes) continue;
 
+            // Only a recipe that actually contributes rows stands in for this one's price.
+            const row = map.get(key);
+            if (row) row.substituted = true;
+
+            if (childId !== null) visited.add(childId);
+            accumulate(childSpec, amount, map, visited);
             if (childId !== null) visited.delete(childId);
         }
     }
@@ -169,14 +191,11 @@
     }
 
     function resolveUnitPrice(item?: IOsrsboxItemWithMeta | null): number | null {
-        if (!item) return null;
         // `cost` is the base game value, not a market price. For an item with no GE
         // market (an untradeable intermediate like "Oak seedling (w)", cost 1) it is
         // not what the player pays, so the price is reported as unknown and the real
         // outlay shows up on the child rows this walk already expands to.
-        const fallback = item.tradeable_on_ge ? (item.cost ?? null) : null;
-        const price = item.highPrice ?? item.lowPrice ?? fallback;
-        return typeof price === 'number' ? price : null;
+        return resolveIngredientUnitPrice(item);
     }
 
     function formatNumber(value: number | null | undefined) {

--- a/src/lib/components/game-item-creation-card/game-item-creation-cost-table.svelte
+++ b/src/lib/components/game-item-creation-card/game-item-creation-cost-table.svelte
@@ -198,6 +198,17 @@
         return resolveIngredientUnitPrice(item);
     }
 
+    /**
+     * A row's display name, or a placeholder when the tree stopped short of loading it.
+     *
+     * The builder caps how much of a recipe it materializes, so a deep or heavily
+     * cross-linked branch can arrive as a bare id. Such a row has no price either, which
+     * already makes the total read as unknown — this just stops the cell rendering blank.
+     */
+    function rowLabel(row: CostRow): string {
+        return row.item?.name ?? 'Unknown item';
+    }
+
     function formatNumber(value: number | null | undefined) {
         if (value === null || value === undefined) return '—';
         return Math.round(value).toLocaleString();
@@ -248,10 +259,10 @@
                                 href={resolve(`/items/${row.item.id}`)}
                                 data-sveltekit-preload-data="hover"
                             >
-                                {row.item.name}
+                                {rowLabel(row)}
                             </a>
                         {:else}
-                            {row.item.name}
+                            {rowLabel(row)}
                         {/if}
                     </Table.Cell>
                     <Table.Cell class="text-end">{formatNumber(row.amount)}</Table.Cell>

--- a/src/lib/components/game-item-creation-card/game-item-tree.svelte
+++ b/src/lib/components/game-item-creation-card/game-item-tree.svelte
@@ -175,7 +175,7 @@
         const { item: resolvedItem, itemId: resolvedItemId } = extractItemDescriptor(rawItem);
         const ingredientItem =
             resolvedItemId !== null && resolvedItemId !== undefined
-                ? expandedItemCache[String(resolvedItemId)] ?? resolvedItem
+                ? (expandedItemCache[String(resolvedItemId)] ?? resolvedItem)
                 : resolvedItem;
         const ingredientId = resolvedItemId ?? `unknown-${index}`;
         const key = `${parentKey}-${ingredientId}-${index}`;
@@ -231,9 +231,7 @@
         };
     }
 
-    function extractItemDescriptor(
-        raw: unknown,
-    ): { item?: IOsrsboxItemWithMeta; itemId: string | number | null } {
+    function extractItemDescriptor(raw: unknown): { item?: IOsrsboxItemWithMeta; itemId: string | number | null } {
         if (!raw) return { itemId: null };
         if (typeof raw === 'string' || typeof raw === 'number') {
             return { itemId: raw };
@@ -242,8 +240,7 @@
 
         const maybeItem = raw as IOsrsboxItemWithMeta & { _id?: unknown; id?: unknown };
         const hasName = 'name' in maybeItem && typeof maybeItem.name === 'string';
-        const directId =
-            typeof maybeItem.id === 'string' || typeof maybeItem.id === 'number' ? maybeItem.id : null;
+        const directId = typeof maybeItem.id === 'string' || typeof maybeItem.id === 'number' ? maybeItem.id : null;
         const objectId = extractObjectId(maybeItem._id ?? (raw as { $oid?: unknown }).$oid ?? raw);
         const itemId = directId ?? objectId;
 
@@ -573,8 +570,9 @@
         if (!itemId) return;
 
         const nativeEvent = params?.event?.event;
-        const hasModifier =
-            Boolean(nativeEvent?.altKey || nativeEvent?.metaKey || nativeEvent?.ctrlKey || nativeEvent?.shiftKey);
+        const hasModifier = Boolean(
+            nativeEvent?.altKey || nativeEvent?.metaKey || nativeEvent?.ctrlKey || nativeEvent?.shiftKey,
+        );
         if (collapseNodesOnClick && params?.data?.hasLazyChildren && params?.data?.nodeKey && !hasModifier) {
             const key = String(params.data.nodeKey);
             if (!expandedSupplyNodes[key]) {

--- a/src/lib/components/global/account-type-select.svelte
+++ b/src/lib/components/global/account-type-select.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+    import * as Select from '$lib/components/ui/select';
+    import { Label } from '$lib/components/ui/label';
+    import { accountTypeOptions, getAccountTypeOption, normalizeAccountType } from '$lib/models/account-type';
+    import type { AccountType } from '$lib/models/account-type';
+
+    const {
+        value,
+        onChange,
+        idPrefix = 'account-type',
+    } = $props<{
+        value?: AccountType | null;
+        onChange: (next: AccountType) => void;
+        idPrefix?: string;
+    }>();
+
+    const selected = $derived(normalizeAccountType(value));
+    const selectedOption = $derived(getAccountTypeOption(selected));
+    const selectId = $derived(`${idPrefix}-account-type`);
+
+    function handleChange(next: string) {
+        onChange(normalizeAccountType(next));
+    }
+</script>
+
+<div>
+    <Label class="capitalize text-xs" for={selectId}>Account type</Label>
+    <Select.Root type="single" value={selected} onValueChange={handleChange}>
+        <Select.Trigger id={selectId}>{selectedOption.label}</Select.Trigger>
+        <Select.Content>
+            <Select.Group>
+                {#each accountTypeOptions as option (option.value)}
+                    <Select.Item value={option.value}>{option.label}</Select.Item>
+                {/each}
+            </Select.Group>
+        </Select.Content>
+    </Select.Root>
+    <p class="text-muted-foreground mt-1 text-xs">{selectedOption.description}</p>
+</div>

--- a/src/lib/components/global/character-switcher.svelte
+++ b/src/lib/components/global/character-switcher.svelte
@@ -4,6 +4,7 @@
     import { User, ChevronsUpDown, Plus, X, Pencil } from 'lucide-svelte';
     import { buttonVariants } from '$lib/components/ui/button';
     import { getStoreRoot } from '$lib/stores/character-store.svelte';
+    import { getAccountTypeOption, isIronmanAccount } from '$lib/models/account-type';
     import { removeSuppliesForCharacter } from '$lib/stores/bank-items-store';
     import { Button } from '$lib/components/ui/button';
     import * as Sidebar from '$lib/components/ui/sidebar';
@@ -19,10 +20,16 @@
     const store = $derived(getStoreRoot());
     const characterList = $derived(store.characters);
 
-    const activeCharacterName = $derived.by(() => {
+    const activeCharacter = $derived.by(() => {
         const activeId = store.activeCharacter;
-        return store.characters.find((c) => activeId === c.id)?.name || 'My character';
+        return store.characters.find((c) => activeId === c.id);
     });
+    const activeCharacterName = $derived(activeCharacter?.name || 'My character');
+
+    // The mode has to be visible wherever the character is. Reading shop-and-alchemy numbers while
+    // believing they are Grand Exchange numbers is the one failure this feature can't afford.
+    const activeAccountType = $derived(getAccountTypeOption(activeCharacter?.accountType));
+    const showAccountBadge = $derived(Boolean(activeCharacter) && isIronmanAccount(activeCharacter?.accountType));
 
     /**
      * Remove a character from the character list. If the removed character is the active character, sets the active
@@ -93,7 +100,17 @@
                 </div>
                 <div class="grid flex-1 text-left text-sm leading-tight">
                     <span class="truncate font-semibold">Select Character</span>
-                    <span class="truncate text-xs text-muted-foreground">{activeCharacterName}</span>
+                    <span class="flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <span class="truncate">{activeCharacterName}</span>
+                        {#if showAccountBadge}
+                            <span
+                                class="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                                title="{activeAccountType.label} — prices don't use the Grand Exchange"
+                            >
+                                {activeAccountType.shortLabel}
+                            </span>
+                        {/if}
+                    </span>
                 </div>
                 <ChevronsUpDown class="ml-auto" />
             </Sidebar.MenuButton>
@@ -112,8 +129,19 @@
             {#each characterList as character (character.id ?? character.name)}
                 <div class="flex gap-1">
                     <!-- "Add character" button -->
-                    <Button variant="ghost" class="flex-1" onclick={() => selectCharacter(character)}>
-                        {character.name}
+                    <Button
+                        variant="ghost"
+                        class="flex-1 !justify-start gap-1.5"
+                        onclick={() => selectCharacter(character)}
+                    >
+                        <span class="truncate">{character.name}</span>
+                        {#if isIronmanAccount(character.accountType)}
+                            <span
+                                class="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
+                            >
+                                {getAccountTypeOption(character.accountType).shortLabel}
+                            </span>
+                        {/if}
                     </Button>
 
                     <!-- Remove character from store's `characters` list. -->

--- a/src/lib/components/global/item-card.svelte
+++ b/src/lib/components/global/item-card.svelte
@@ -49,6 +49,13 @@
     }>();
 
     let timeSincePriceTime = $state('Calculating...');
+    // Why a price is missing. Untradeables reach the browse list under Ironman mode, and a bare dash
+    // with no explanation reads as broken data rather than as a fact about the item.
+    const missingPriceReason = $derived.by(() => {
+        if (hasPrice) return null;
+        if (item.tradeable_on_ge === false) return 'Not tradeable';
+        return 'No recent trades';
+    });
     const iconSrc = $derived(iconToDataUri(item.icon));
     const priceValue = $derived(resolveDisplayPrice(item));
     const hasPrice = $derived(priceValue !== null);
@@ -172,6 +179,10 @@
                 {#if priceTime}
                     <p class="text-muted-foreground text-xs animate-fade-in">
                         {timeSincePriceTime}
+                    </p>
+                {:else if missingPriceReason}
+                    <p class="text-muted-foreground text-xs animate-fade-in">
+                        {missingPriceReason}
                     </p>
                 {/if}
                 {#if showProfit && hasProfit}

--- a/src/lib/components/global/item-card.svelte
+++ b/src/lib/components/global/item-card.svelte
@@ -38,6 +38,7 @@
         allowHide = true,
         showProfit = false,
         profitContext = 'Profit',
+        ironman = false,
     } = $props<{
         item?: IGameItem;
         loading?: boolean;
@@ -46,20 +47,24 @@
         allowHide?: boolean;
         showProfit?: boolean;
         profitContext?: string;
+        ironman?: boolean;
     }>();
 
     let timeSincePriceTime = $state('Calculating...');
-    // Why a price is missing. Untradeables reach the browse list under Ironman mode, and a bare dash
-    // with no explanation reads as broken data rather than as a fact about the item.
-    const missingPriceReason = $derived.by(() => {
-        if (hasPrice) return null;
-        if (item.tradeable_on_ge === false) return 'Not tradeable';
-        return 'No recent trades';
-    });
     const iconSrc = $derived(iconToDataUri(item.icon));
     const priceValue = $derived(resolveDisplayPrice(item));
     const hasPrice = $derived(priceValue !== null);
     const formattedPrice = $derived(hasPrice ? formatWithCommas(priceValue!) : '—');
+    // Why a price is missing. Untradeables reach the browse list under Ironman mode, and a bare dash
+    // with no explanation reads as broken data rather than as a fact about the item.
+    const missingPriceReason = $derived.by(() => {
+        if (hasPrice) return null;
+        if (ironman) return 'No sell value';
+        if (item.tradeable_on_ge === false) return 'Not tradeable';
+        return 'No recent trades';
+    });
+    // Where an Ironman value came from. Shop names join this once shop data is scraped.
+    const valueSourceLabel = $derived(ironman && hasPrice ? 'High alch' : null);
     const priceTime = $derived(resolveDisplayTime(item));
     const profitValue = $derived(resolveProfit(item));
     const hasProfit = $derived(typeof profitValue === 'number' && Number.isFinite(profitValue));
@@ -78,7 +83,9 @@
     });
 
     function resolveDisplayPrice(item: IGameItem): number | null {
-        const price = item.highPrice ?? item.lowPrice ?? null;
+        // An Ironman cannot realise a Grand Exchange price, so showing one as the headline number
+        // states a value they can never get. The server sends what they can actually clear.
+        const price = ironman ? item.ironmanExitValue : (item.highPrice ?? item.lowPrice ?? null);
         if (typeof price !== 'number' || !Number.isFinite(price) || price <= 0) return null;
         return price;
     }
@@ -176,7 +183,11 @@
                 <p class="text-2xl font-bold animate-fade-in">
                     <span class="text-primary">{formattedPrice}</span>{#if hasPrice}gp{/if}
                 </p>
-                {#if priceTime}
+                {#if valueSourceLabel}
+                    <p class="text-muted-foreground text-xs animate-fade-in">
+                        {valueSourceLabel}
+                    </p>
+                {:else if priceTime && !ironman}
                     <p class="text-muted-foreground text-xs animate-fade-in">
                         {timeSincePriceTime}
                     </p>

--- a/src/lib/components/items/game-items-page.svelte
+++ b/src/lib/components/items/game-items-page.svelte
@@ -8,11 +8,8 @@
     import { defaultSkillLevels } from '$lib/constants/default-skill-levels';
     import type { SkillTreePage } from '$lib/constants/skill-tree-pages';
     import { getStoreRoot } from '$lib/stores/character-store.svelte';
-    import {
-        bankItemsStore,
-        ensureSuppliesForCharacter,
-        getSuppliesForCharacter,
-    } from '$lib/stores/bank-items-store';
+    import { canUseGrandExchange, getAccountTypeOption } from '$lib/models/account-type';
+    import { bankItemsStore, ensureSuppliesForCharacter, getSuppliesForCharacter } from '$lib/stores/bank-items-store';
     import { filterItemsStore } from '$lib/stores/filter-items-by-player-levels';
     import { itemsPagePreferences } from '$lib/stores/items-page-preferences';
     import type { IGameItem } from '$lib/models/game-item';
@@ -68,6 +65,10 @@
         return characters.find((c) => String(c.id) === String(targetId));
     });
     const activeSkillLevels = $derived(normalizeSkillLevels(activeCharacter?.skillLevels, Boolean(activeCharacter)));
+    // Pricing follows the active character rather than a page toggle, so browsing, an item page and
+    // search cannot disagree about which prices the reader is looking at.
+    const ironmanMode = $derived(!canUseGrandExchange(activeCharacter?.accountType));
+    const activeAccountType = $derived(getAccountTypeOption(activeCharacter?.accountType));
     let skillFilterChecked = $state($filterItemsStore.filterItemsByPlayerLevels);
     const skillFilterEnabled = $derived(Boolean(skillFilterChecked && activeSkillLevels));
     const skillLevelsForQuery = $derived(skillFilterEnabled ? activeSkillLevels : undefined);
@@ -101,9 +102,7 @@
     const filterLabel = $derived(
         filterOptions.find((option) => option.value === filterSelected)?.label ?? 'Filter items',
     );
-    const sortLabel = $derived(
-        sortOptions.find((option) => option.value === sortOrderSelected)?.label ?? 'Sort items',
-    );
+    const sortLabel = $derived(sortOptions.find((option) => option.value === sortOrderSelected)?.label ?? 'Sort items');
     const profitModeEnabled = $derived(profitModeChecked);
     const profitContextLabel = $derived(profitModeEnabled && useSuppliesChecked ? 'Profit (supplies)' : 'Profit');
     const suppliesParam = $derived.by(() => {
@@ -203,6 +202,7 @@
         supplies?: string | null,
         suppliesEnabled?: boolean,
         profitMode?: boolean,
+        ironman?: boolean,
     ) {
         if (listAbort) listAbort.abort();
         const controller = new AbortController();
@@ -218,6 +218,7 @@
             supplies,
             suppliesEnabled,
             profitMode,
+            ironman,
         });
         const cached = !skipCacheOnce && !shouldForceLoading ? readItemsCache(cacheKey) : null;
         skipCacheOnce = false;
@@ -255,6 +256,9 @@
             }
             if (profitMode) {
                 searchParams.set('profitMode', '1');
+            }
+            if (ironman) {
+                searchParams.set('ironman', '1');
             }
 
             const response = await fetch(`/api/game-items?${searchParams.toString()}`, {
@@ -302,6 +306,7 @@
             suppliesParam,
             suppliesActive,
             profitModeEnabled,
+            ironmanMode,
         );
     });
 
@@ -414,6 +419,7 @@
         supplies?: string | null;
         suppliesEnabled?: boolean;
         profitMode?: boolean;
+        ironman?: boolean;
     }) {
         if (typeof window === 'undefined') return '';
         const normalizedSkills = normalizeRecord(params.skillLevels);
@@ -427,6 +433,7 @@
             supplies: params.supplies ?? null,
             useSupplies: params.suppliesEnabled ?? useSuppliesChecked,
             profitMode: params.profitMode ?? profitModeChecked,
+            ironman: params.ironman ?? ironmanMode,
         };
         return `ge-skiller:items-cache:${JSON.stringify(payload)}`;
     }
@@ -468,6 +475,18 @@
             <h1 class="text-3xl font-bold">{headingLabel}</h1>
         </div>
     </div>
+
+    {#if ironmanMode}
+        <div class="content-sizing">
+            <div class="mb-4 rounded-lg border border-border bg-muted/40 p-3 text-sm">
+                <span class="font-semibold">You're in {activeAccountType.label} mode.</span>
+                <span class="text-muted-foreground">
+                    The GP values shown in Ironman mode are derived from alchemy and base shop values (e.g. before the
+                    shop value of an item drops from selling multiple).
+                </span>
+            </div>
+        </div>
+    {/if}
 
     <div class="border-b border-border">
         <div class="content-sizing">

--- a/src/lib/components/items/game-items-page.svelte
+++ b/src/lib/components/items/game-items-page.svelte
@@ -104,7 +104,10 @@
     );
     const sortLabel = $derived(sortOptions.find((option) => option.value === sortOrderSelected)?.label ?? 'Sort items');
     const profitModeEnabled = $derived(profitModeChecked);
-    const profitContextLabel = $derived(profitModeEnabled && useSuppliesChecked ? 'Profit (supplies)' : 'Profit');
+    const profitContextLabel = $derived.by(() => {
+        const base = ironmanMode ? 'Ironman profit' : 'Profit';
+        return profitModeEnabled && useSuppliesChecked ? `${base} (supplies)` : base;
+    });
     const suppliesParam = $derived.by(() => {
         if (!useSuppliesChecked) return null;
         const entries: Array<[string, number]> = [];
@@ -647,6 +650,7 @@
                         allowFavorite={true}
                         showProfit={profitModeEnabled}
                         profitContext={profitContextLabel}
+                        ironman={ironmanMode}
                     />
                 {/each}
             {/if}

--- a/src/lib/constants/alchemy.ts
+++ b/src/lib/constants/alchemy.ts
@@ -1,0 +1,37 @@
+/**
+ * The rune consumed by one cast of High or Low Level Alchemy.
+ *
+ * Alchemy is an Ironman's most common exit from an item: no shop has to want it and no trade has to
+ * happen. What they actually clear is the alchemy value minus the rune the cast burns, so the rune's
+ * price is an input to every alchemy figure the app shows them.
+ */
+export const NATURE_RUNE_ITEM_ID = 561;
+
+/**
+ * Fallback price for a nature rune when its live price cannot be read.
+ *
+ * Prefer the live Grand Exchange price wherever it can be fetched — a hardcoded gp figure goes stale
+ * the moment the market moves. This exists only so a failed lookup degrades to a slightly wrong
+ * number instead of silently pricing the rune at zero, which would overstate every alchemy value.
+ */
+export const NATURE_RUNE_FALLBACK_PRICE = 100;
+
+/**
+ * What one alchemy cast nets after paying for the rune it burns.
+ *
+ * Note this deliberately differs from the "alch profit" a main cares about, which is the alchemy
+ * value minus what they paid on the Grand Exchange. An Ironman never bought the item at a market
+ * price, so subtracting one would be meaningless to them.
+ * @param alchValue - The item's high or low alchemy value.
+ * @param natureRunePrice - What a nature rune costs, defaulting to the fallback above.
+ * @returns The gp cleared by the cast, or null when the item has no alchemy value.
+ */
+export function alchemyValueAfterRune(
+    alchValue?: number | null,
+    natureRunePrice: number = NATURE_RUNE_FALLBACK_PRICE,
+): number | null {
+    if (typeof alchValue !== 'number' || !Number.isFinite(alchValue) || alchValue <= 0) return null;
+
+    const runeCost = Number.isFinite(natureRunePrice) && natureRunePrice > 0 ? natureRunePrice : 0;
+    return alchValue - runeCost;
+}

--- a/src/lib/constants/item-tree.ts
+++ b/src/lib/constants/item-tree.ts
@@ -1,1 +1,17 @@
 export const MAX_ITEM_TREE_DEPTH = 12;
+
+/**
+ * Ceiling on how many ingredient nodes one item tree may materialize.
+ *
+ * Depth alone does not bound the tree. Recolour recipes reference each other —
+ * `Black cape` is made from `Blue cape`, which is made from `Black cape` under a second
+ * OSRSBox document id — and the permutations of that web run to hundreds of thousands of
+ * nodes long before twelve levels are up. 51 items exceeded 100,000 nodes with only a
+ * repeated-ancestor guard in place, which is both a payload no browser wants and, past
+ * roughly 6MB, a response the serverless runtime refuses outright.
+ *
+ * Ingredients past the budget keep their raw id reference instead of being materialized.
+ * The tree chart already fetches those on demand, and the cost table reports the total as
+ * unknown rather than quietly leaving them out of the sum.
+ */
+export const MAX_ITEM_TREE_NODES = 1000;

--- a/src/lib/helpers/ingredient-price.test.ts
+++ b/src/lib/helpers/ingredient-price.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { isCurrencyItem, resolveIngredientUnitPrice } from './ingredient-price';
+import { isCurrencyItem, resolveIngredientUnitPrice, resolveIronmanUnitValue } from './ingredient-price';
 
 describe('resolveIngredientUnitPrice', () => {
     it('prefers the live high price', () => {
@@ -60,5 +60,49 @@ describe('isCurrencyItem', () => {
         expect(isCurrencyItem('coins')).toBe(false);
         expect(isCurrencyItem(null)).toBe(false);
         expect(isCurrencyItem(undefined)).toBe(false);
+    });
+});
+
+describe('resolveIronmanUnitValue', () => {
+    // A Grand Exchange price is a number an Ironman can never realise, so it must not leak in.
+    it('ignores the Grand Exchange price entirely', () => {
+        expect(
+            resolveIronmanUnitValue(
+                { name: 'Adamant platebody', tradeable_on_ge: true, cost: 6400, highPrice: 9999, highalch: 3840 },
+                100,
+            ),
+        ).toBe(3740);
+    });
+
+    it('nets the alchemy value against the nature rune', () => {
+        expect(resolveIronmanUnitValue({ name: 'Rune scimitar', highalch: 900 }, 100)).toBe(800);
+    });
+
+    // Nobody is obliged to alch at a loss, so the value floors at zero rather than going negative.
+    it('floors a losing cast at zero', () => {
+        expect(resolveIronmanUnitValue({ name: 'Bronze dagger', highalch: 6 }, 100)).toBe(0);
+    });
+
+    // Unknown and worthless are different claims. Shop prices may yet value these, so nulling keeps
+    // them out of the ROI sort instead of ranking them on a number the app invented.
+    it('reports no value when the item cannot be alched', () => {
+        expect(resolveIronmanUnitValue({ name: 'Oak seedling (w)', cost: 1 }, 100)).toBeNull();
+        expect(resolveIronmanUnitValue({ name: 'Oak seedling (w)', cost: 1, highalch: 0 }, 100)).toBeNull();
+    });
+
+    // Coins are money whoever is holding them, the same exception the GE pricing path makes.
+    it('prices currency at its cost', () => {
+        expect(resolveIronmanUnitValue({ name: 'Coins', cost: 1, tradeable_on_ge: false }, 100)).toBe(1);
+    });
+
+    it('reports no value for a missing item', () => {
+        expect(resolveIronmanUnitValue(null, 100)).toBeNull();
+    });
+
+    // The rune price moves with the market, so the same item is worth less when runes cost more.
+    it('tracks the nature rune price it is given', () => {
+        const item = { name: 'Rune scimitar', highalch: 900 };
+        expect(resolveIronmanUnitValue(item, 100)).toBe(800);
+        expect(resolveIronmanUnitValue(item, 250)).toBe(650);
     });
 });

--- a/src/lib/helpers/ingredient-price.test.ts
+++ b/src/lib/helpers/ingredient-price.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+import { isCurrencyItem, resolveIngredientUnitPrice } from './ingredient-price';
+
+describe('resolveIngredientUnitPrice', () => {
+    it('prefers the live high price', () => {
+        expect(
+            resolveIngredientUnitPrice({
+                name: 'Acorn',
+                tradeable_on_ge: true,
+                cost: 47,
+                highPrice: 139,
+                lowPrice: 120,
+            }),
+        ).toBe(139);
+    });
+
+    it('falls back to the low price before touching cost', () => {
+        expect(resolveIngredientUnitPrice({ name: 'Acorn', tradeable_on_ge: true, cost: 47, lowPrice: 120 })).toBe(120);
+    });
+
+    it('uses cost for a tradeable item with no live price', () => {
+        expect(resolveIngredientUnitPrice({ name: 'Acorn', tradeable_on_ge: true, cost: 47 })).toBe(47);
+    });
+
+    it('reports no price for an untradeable ingredient', () => {
+        // The bug this exists for: cost 1 made Oak sapling look like a 31,500% return.
+        expect(resolveIngredientUnitPrice({ name: 'Oak seedling (w)', tradeable_on_ge: false, cost: 1 })).toBeNull();
+    });
+
+    it('prices coins from cost even though they are untradeable', () => {
+        expect(resolveIngredientUnitPrice({ name: 'Coins', tradeable_on_ge: false, cost: 1 })).toBe(1);
+    });
+
+    it('prices platinum tokens from cost', () => {
+        expect(resolveIngredientUnitPrice({ name: 'Platinum token', tradeable_on_ge: false, cost: 1000 })).toBe(1000);
+    });
+
+    it('reports no price for an unresolved ingredient', () => {
+        expect(resolveIngredientUnitPrice(null)).toBeNull();
+        expect(resolveIngredientUnitPrice(undefined)).toBeNull();
+    });
+
+    it('treats a missing tradeable flag as not tradeable rather than as true', () => {
+        expect(resolveIngredientUnitPrice({ name: 'Lovakite ore', cost: 80 })).toBeNull();
+    });
+
+    it('reports no price when nothing is priced at all', () => {
+        expect(resolveIngredientUnitPrice({ name: 'Bone in vinegar', tradeable_on_ge: true })).toBeNull();
+    });
+});
+
+describe('isCurrencyItem', () => {
+    it('matches the money items exactly', () => {
+        expect(isCurrencyItem('Coins')).toBe(true);
+        expect(isCurrencyItem('Platinum token')).toBe(true);
+    });
+
+    it('does not match a merely coin-shaped name', () => {
+        expect(isCurrencyItem('Coins (Deadman)')).toBe(false);
+        expect(isCurrencyItem('coins')).toBe(false);
+        expect(isCurrencyItem(null)).toBe(false);
+        expect(isCurrencyItem(undefined)).toBe(false);
+    });
+});

--- a/src/lib/helpers/ingredient-price.ts
+++ b/src/lib/helpers/ingredient-price.ts
@@ -7,6 +7,7 @@
  * "Oak seedling (w)" carries `cost: 1`, and spending that made saplings look like a
  * 31,500% return.
  */
+import { NATURE_RUNE_FALLBACK_PRICE, alchemyValueAfterRune } from '$lib/constants/alchemy';
 import type { IOsrsboxItem } from '$lib/models/osrsbox-db-item';
 
 /**
@@ -54,4 +55,35 @@ export function resolveIngredientUnitPrice(item?: PricedItem | null): number | n
     const price = item.highPrice ?? item.lowPrice ?? usableCost;
 
     return typeof price === 'number' ? price : null;
+}
+
+/**
+ * What one unit of an item is worth to an account that cannot trade.
+ *
+ * An Ironman's only reliable exit is alchemy, so the alchemy value net of the nature rune the cast
+ * burns is what the item is really worth to them — the Grand Exchange price is a number they can
+ * never realise. Currency is the exception for the same reason it is in
+ * {@link resolveIngredientUnitPrice}: coins are money, and 5 coins is 5gp whoever is holding them.
+ *
+ * Returns null rather than 0 when nothing values the item. Unknown and worthless are different
+ * claims, and shop prices — which will join this function once scraped — may yet value it. Nulling
+ * keeps the item out of the ROI sort instead of ranking it on a number the app invented.
+ *
+ * A cast that costs more than it returns nets 0, not a negative: nobody is obliged to alch.
+ * @param item - The item document, or null when it could not be resolved.
+ * @param natureRunePrice - What a nature rune costs.
+ * @returns Value in gp, or null when nothing the app knows about values the item.
+ */
+export function resolveIronmanUnitValue(
+    item?: (PricedItem & { highalch?: number | null }) | null,
+    natureRunePrice: number = NATURE_RUNE_FALLBACK_PRICE,
+): number | null {
+    if (!item) return null;
+
+    if (isCurrencyItem(item.name)) return item.cost ?? null;
+
+    const alchemyNet = alchemyValueAfterRune(item.highalch, natureRunePrice);
+    if (alchemyNet === null) return null;
+
+    return Math.max(0, alchemyNet);
 }

--- a/src/lib/helpers/ingredient-price.ts
+++ b/src/lib/helpers/ingredient-price.ts
@@ -1,0 +1,57 @@
+/**
+ * What a crafter actually pays for one unit of an ingredient.
+ *
+ * The Grand Exchange price comes first. `cost` — OSRSBox's base game value — is only a
+ * price for something you can actually buy at it, so it is used for GE-tradeable items
+ * and for currency, and withheld otherwise: an untradeable intermediate like
+ * "Oak seedling (w)" carries `cost: 1`, and spending that made saplings look like a
+ * 31,500% return.
+ */
+import type { IOsrsboxItem } from '$lib/models/osrsbox-db-item';
+
+/**
+ * Items that *are* money, so their `cost` is a literal gp price rather than a valuation.
+ *
+ * Both are flagged untradeable — you cannot list coins on the GE — but a recipe that asks
+ * for 5 coins costs 5gp, and roughly a third of every recipe in the dataset charges a coin
+ * fee. Withholding a price for them would take those items out of the profit and ROI sorts
+ * entirely.
+ */
+const CURRENCY_ITEM_NAMES = ['Coins', 'Platinum token'];
+
+/**
+ * The subset of an item this module reads.
+ *
+ * Every field is optional: ingredients reach here from projections and from the
+ * loosened `IOsrsboxItemWithMeta`, and a missing flag means "not set", never "true".
+ */
+export type PricedItem = Partial<Pick<IOsrsboxItem, 'name' | 'cost' | 'tradeable_on_ge'>> & {
+    highPrice?: number | null;
+    lowPrice?: number | null;
+};
+
+/**
+ * Whether an item's `cost` is denominated in the coins it is made of.
+ * @param name - The item's in-game name.
+ * @returns True for coins and platinum tokens.
+ */
+export function isCurrencyItem(name?: string | null): boolean {
+    return !!name && CURRENCY_ITEM_NAMES.includes(name);
+}
+
+/** The item names whose `cost` counts as a price, for the aggregation's `$in`. */
+export const currencyItemNames: readonly string[] = CURRENCY_ITEM_NAMES;
+
+/**
+ * Prices one unit of an ingredient, or reports the price as unknown.
+ * @param item - The ingredient document, or null when it could not be resolved.
+ * @returns Price in gp, or null when the item has no price anyone actually pays.
+ */
+export function resolveIngredientUnitPrice(item?: PricedItem | null): number | null {
+    if (!item) return null;
+
+    const usableCost = item.tradeable_on_ge || isCurrencyItem(item.name) ? (item.cost ?? null) : null;
+    const price = item.highPrice ?? item.lowPrice ?? usableCost;
+
+    return typeof price === 'number' ? price : null;
+}

--- a/src/lib/helpers/item-preference.test.ts
+++ b/src/lib/helpers/item-preference.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'bun:test';
+import { itemPreferenceRank, pickPreferredItem } from './item-preference';
+
+// Modelled on the real "Acorn" group: four duplicate ids with no GE market, the
+// canonical tradeable item, and a bank placeholder.
+const acornDuplicate = { id: 5111, duplicate: true, tradeable_on_ge: false };
+const acornCanonical = { id: 5312, duplicate: false, tradeable_on_ge: true };
+const acornPlaceholder = { id: 13759, duplicate: true, placeholder: true, tradeable_on_ge: false };
+
+describe('pickPreferredItem', () => {
+    it('prefers the canonical item over an OSRSBox duplicate', () => {
+        expect(pickPreferredItem([acornDuplicate, acornCanonical])?.id).toBe(5312);
+    });
+
+    it('prefers the canonical item regardless of input order', () => {
+        expect(pickPreferredItem([acornCanonical, acornDuplicate])?.id).toBe(5312);
+    });
+
+    it('picks the canonical item out of the full real-world Acorn group', () => {
+        const group = [
+            acornDuplicate,
+            { id: 5112, duplicate: true, tradeable_on_ge: false },
+            { id: 5113, duplicate: true, tradeable_on_ge: false },
+            { id: 5114, duplicate: true, tradeable_on_ge: false },
+            acornCanonical,
+            acornPlaceholder,
+        ];
+        expect(pickPreferredItem(group)?.id).toBe(5312);
+    });
+
+    it('never picks a placeholder over a real item', () => {
+        expect(pickPreferredItem([acornPlaceholder, acornDuplicate])?.id).toBe(5111);
+    });
+
+    it('never picks a noted item over the unnoted one, even when the note is tradeable', () => {
+        const noted = { id: 100, noted: true, tradeable_on_ge: true };
+        const unnoted = { id: 101, noted: false, tradeable_on_ge: false };
+        expect(pickPreferredItem([noted, unnoted])?.id).toBe(101);
+    });
+
+    it('prefers a GE-tradeable item when nothing else separates the candidates', () => {
+        const untradeable = { id: 200, tradeable_on_ge: false };
+        const tradeable = { id: 201, tradeable_on_ge: true };
+        expect(pickPreferredItem([untradeable, tradeable])?.id).toBe(201);
+    });
+
+    it('breaks remaining ties on the lowest id so the choice is deterministic', () => {
+        const a = { id: 900, tradeable_on_ge: true };
+        const b = { id: 300, tradeable_on_ge: true };
+        expect(pickPreferredItem([a, b])?.id).toBe(300);
+        expect(pickPreferredItem([b, a])?.id).toBe(300);
+    });
+
+    it('falls back to a duplicate when no canonical document exists', () => {
+        const only = [{ id: 1, duplicate: true }, { id: 2, duplicate: true }];
+        expect(pickPreferredItem(only)?.id).toBe(1);
+    });
+
+    it('returns null for an empty list', () => {
+        expect(pickPreferredItem([])).toBeNull();
+    });
+
+    it('treats missing flags as canonical rather than assuming the worst', () => {
+        const bare = { id: 7 };
+        const dup = { id: 6, duplicate: true };
+        expect(pickPreferredItem([dup, bare])?.id).toBe(7);
+    });
+});
+
+describe('itemPreferenceRank', () => {
+    it('ranks a canonical tradeable item best', () => {
+        expect(itemPreferenceRank(acornCanonical)).toBe(0);
+    });
+
+    it('ranks a duplicate worse than a merely untradeable canonical item', () => {
+        expect(itemPreferenceRank(acornDuplicate)).toBeGreaterThan(
+            itemPreferenceRank({ id: 1, duplicate: false, tradeable_on_ge: false }),
+        );
+    });
+});

--- a/src/lib/helpers/item-preference.test.ts
+++ b/src/lib/helpers/item-preference.test.ts
@@ -52,7 +52,10 @@ describe('pickPreferredItem', () => {
     });
 
     it('falls back to a duplicate when no canonical document exists', () => {
-        const only = [{ id: 1, duplicate: true }, { id: 2, duplicate: true }];
+        const only = [
+            { id: 1, duplicate: true },
+            { id: 2, duplicate: true },
+        ];
         expect(pickPreferredItem(only)?.id).toBe(1);
     });
 

--- a/src/lib/helpers/item-preference.ts
+++ b/src/lib/helpers/item-preference.ts
@@ -1,0 +1,90 @@
+/**
+ * Chooses which document represents an item when several share the same name.
+ *
+ * The OSRSBox dataset stores one document per in-game item id, and a single name can
+ * cover many ids: "Acorn" exists as ids 5111-5114 (all flagged `duplicate`), the real
+ * tradeable item 5312, and a bank placeholder 13759. Only 5312 has a Grand Exchange
+ * market, so it is the only one that can be priced.
+ *
+ * Ingredient resolution used to take whichever document happened to come first — by
+ * `_id` in the lookup map, by natural order in the `findOne` fallback — which handed
+ * back the unpriced duplicate and made anything crafted from it look free. Selection is
+ * ranked instead, so the canonical document wins regardless of storage order.
+ */
+
+/** The subset of an item document that determines how canonical it is. */
+export interface PreferableItem {
+    id?: number | null;
+    /** OSRSBox marks redundant ids for the same in-game item with this. */
+    duplicate?: boolean | null;
+    /** Bank placeholders are never a real item. */
+    placeholder?: boolean | null;
+    /** A bank note is not the item it stands for. */
+    noted?: boolean | null;
+    /** Only GE-tradeable documents carry a market price. */
+    tradeable_on_ge?: boolean | null;
+}
+
+/**
+ * Penalty weights, worst first. The values are powers of two so the comparison is
+ * lexicographic: no combination of lesser faults can outweigh a greater one. A
+ * duplicate is therefore never chosen over a canonical document, however untradeable
+ * that canonical document happens to be.
+ */
+const PENALTY_DUPLICATE = 8;
+const PENALTY_PLACEHOLDER = 4;
+const PENALTY_NOTED = 2;
+const PENALTY_NOT_TRADEABLE = 1;
+
+/**
+ * Scores how poorly a document represents its name. Lower is better; 0 is a canonical,
+ * unnoted, non-placeholder item with a GE market.
+ *
+ * Absent flags count as "not set" rather than true, so a sparse document is treated as
+ * canonical instead of being penalised for fields it never had.
+ * @param item - The item document to score.
+ * @returns The penalty score, where lower is more canonical.
+ */
+export function itemPreferenceRank(item: PreferableItem): number {
+    let rank = 0;
+
+    if (item.duplicate === true) rank += PENALTY_DUPLICATE;
+    if (item.placeholder === true) rank += PENALTY_PLACEHOLDER;
+    if (item.noted === true) rank += PENALTY_NOTED;
+    if (item.tradeable_on_ge !== true) rank += PENALTY_NOT_TRADEABLE;
+
+    return rank;
+}
+
+/**
+ * Picks the document that best represents the item shared by all the candidates.
+ *
+ * Ties break on the lowest in-game id, so the result does not depend on the order the
+ * documents came out of the database. Every name in the dataset has at least one
+ * non-duplicate document, but the ranking still degrades gracefully if that stops being
+ * true: it returns the least-bad candidate rather than nothing.
+ * @param items - Candidate documents that share a name.
+ * @returns The preferred document, or null when given no candidates.
+ */
+export function pickPreferredItem<T extends PreferableItem>(items: readonly T[]): T | null {
+    let best: T | null = null;
+    let bestRank = Number.POSITIVE_INFINITY;
+
+    for (const item of items) {
+        const rank = itemPreferenceRank(item);
+
+        if (rank < bestRank) {
+            best = item;
+            bestRank = rank;
+            continue;
+        }
+
+        if (rank === bestRank && best) {
+            const bestId = best.id ?? Number.POSITIVE_INFINITY;
+            const candidateId = item.id ?? Number.POSITIVE_INFINITY;
+            if (candidateId < bestId) best = item;
+        }
+    }
+
+    return best;
+}

--- a/src/lib/helpers/wiki-creation-variants.test.ts
+++ b/src/lib/helpers/wiki-creation-variants.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'bun:test';
+import { selectMethodsForVersion } from './wiki-creation-variants';
+
+/** Shorthand for the only field the selector reads. */
+const m = (methodName?: string) => ({ methodName });
+
+describe('selectMethodsForVersion', () => {
+    it('keeps only the panel labelled with the item version', () => {
+        // oldschool.runescape.wiki/w/Steel_javelin#Poison
+        const methods = [m('Unpoisoned'), m('Poison'), m('Poison+'), m('Poison++')];
+
+        expect(selectMethodsForVersion(methods, 'Poison', ['Unpoisoned', 'Poison', 'Poison+', 'Poison++'])).toEqual([
+            m('Poison'),
+        ]);
+    });
+
+    it('does not let "Poison" swallow "Poison+"', () => {
+        const methods = [m('Poison'), m('Poison+'), m('Poison++')];
+
+        expect(selectMethodsForVersion(methods, 'Poison+', ['Poison', 'Poison+', 'Poison++'])).toEqual([m('Poison+')]);
+    });
+
+    it('drops sibling-labelled panels when the item version has no panel of its own', () => {
+        // Steel bolts labels its fletching panels by feather, but its poisoning panels
+        // by version. Unpoisoned bolts must keep the feathers and lose the poisons.
+        const methods = [m('Feather'), m('Yellow feather'), m('Poison'), m('Poison+'), m('Poison++')];
+
+        const kept = selectMethodsForVersion(methods, 'Unpoisoned', ['Unpoisoned', 'Poison', 'Poison+', 'Poison++']);
+
+        expect(kept).toEqual([m('Feather'), m('Yellow feather')]);
+    });
+
+    it('matches an underscored anchor against a spaced panel label', () => {
+        const methods = [m('Unpoisoned'), m('Karambwan poison')];
+
+        expect(selectMethodsForVersion(methods, 'Karambwan_poison', ['Unpoisoned', 'Karambwan_poison'])).toEqual([
+            m('Karambwan poison'),
+        ]);
+    });
+
+    it('ignores case and a non-breaking space in either label', () => {
+        const methods = [m('4 dose'), m('3 dose')];
+
+        expect(selectMethodsForVersion(methods, '4 DOSE', ['4 dose', '3 dose'])).toEqual([m('4 dose')]);
+    });
+
+    it('keeps every method when the page labels by something other than version', () => {
+        // Candle lantern's panels are named for the candle, not for the lit/unlit version.
+        const methods = [m('White candle'), m('Black candle')];
+        const versions = ['Unlit (white candle)', 'Lit (white candle)'];
+
+        expect(selectMethodsForVersion(methods, 'Lit (white candle)', versions)).toEqual(methods);
+    });
+
+    it('keeps every method when the section has no labels at all', () => {
+        // Oak seedling's Creation section is plain subsections: Planting, then Watering.
+        const methods = [m(), m()];
+
+        expect(selectMethodsForVersion(methods, 'Watered', ['Unwatered', 'Watered'])).toEqual(methods);
+    });
+
+    it('returns nothing when every panel belongs to a sibling', () => {
+        // Abyssal dagger documents only the three poisoning recipes: the plain dagger is a
+        // drop, not a craft. Handing it the cheapest of them costed a 2.2M item at 399gp.
+        const methods = [m('Poison'), m('Poison+'), m('Poison++')];
+
+        expect(selectMethodsForVersion(methods, 'Unpoisoned', ['Unpoisoned', 'Poison', 'Poison+', 'Poison++'])).toEqual(
+            [],
+        );
+    });
+
+    it('empties a lone panel that belongs to a sibling', () => {
+        const methods = [m('Poison')];
+
+        expect(selectMethodsForVersion(methods, 'Unpoisoned', ['Unpoisoned', 'Poison'])).toEqual([]);
+    });
+
+    it('leaves unversioned items untouched', () => {
+        const methods = [m('Smithing'), m('Imbuing')];
+
+        expect(selectMethodsForVersion(methods, null, ['Smithing'])).toEqual(methods);
+    });
+
+    it('keeps a lone unlabelled method', () => {
+        const methods = [m()];
+
+        expect(selectMethodsForVersion(methods, 'Unpoisoned', ['Unpoisoned', 'Poison'])).toEqual(methods);
+    });
+
+    it('keeps everything when no sibling versions are known', () => {
+        // Without siblings there is nothing to attribute a panel to, so nothing is dropped.
+        const methods = [m('Poison'), m('Poison+')];
+
+        expect(selectMethodsForVersion(methods, 'Unpoisoned', [])).toEqual(methods);
+    });
+
+    it('preserves wiki order among the kept methods', () => {
+        const methods = [m('Feather'), m('Poison'), m('Yellow feather'), m('Poison+')];
+
+        expect(selectMethodsForVersion(methods, 'Unpoisoned', ['Unpoisoned', 'Poison', 'Poison+'])).toEqual([
+            m('Feather'),
+            m('Yellow feather'),
+        ]);
+    });
+});

--- a/src/lib/helpers/wiki-creation-variants.ts
+++ b/src/lib/helpers/wiki-creation-variants.ts
@@ -1,0 +1,87 @@
+/**
+ * Picks the creation methods that belong to one variant of a multi-version wiki page.
+ *
+ * `wiki_url` anchors an item at a single infobox version ("Steel dart#Poison"), but the
+ * wiki API has no way to fetch part of a section: scraping the page returns *every*
+ * variant's recipe. Storing all of them makes the item's primary spec — the first one
+ * with ingredients — belong to whichever variant the wiki happens to list first, so
+ * `Steel dart(p)` was costed as ten unpoisoned darts and `Steel bolts` picked a
+ * poisoning recipe.
+ *
+ * The wiki labels those panels with the same version names OSRSBox anchors on, so the
+ * label is the discriminator. It is not always present — plenty of Creation sections are
+ * plain subsections with no labels at all, and some pages label by material rather than
+ * by version ("Feather", "Yellow feather") — so every step here degrades to "keep
+ * everything" rather than dropping data it cannot account for.
+ *
+ * See `scripts/WIKI-NAME-NORMALIZATION.md`.
+ */
+
+/** The shape this module needs from a scraped wiki method. */
+export interface VariantLabelled {
+    methodName?: string;
+}
+
+/**
+ * Folds a version or method label to a comparable form.
+ *
+ * Wiki anchors arrive underscored ("Karambwan_poison") while panel labels are spaced, and
+ * either can carry a non-breaking space, so every run of whitespace or underscore — `\s`
+ * covers U+00A0 — collapses to a single space.
+ */
+function normalizeVariantLabel(label: string): string {
+    return label
+        .replace(/[\s_]+/g, ' ')
+        .trim()
+        .toLowerCase();
+}
+
+/**
+ * Narrows scraped methods to the ones that describe the requested infobox version.
+ *
+ * Resolution order:
+ *  1. Methods labelled with this item's own version win outright.
+ *  2. Otherwise methods labelled with a *sibling* version are dropped — that is what
+ *     keeps the poison recipes off unpoisoned `Steel bolts`, whose own panels are
+ *     labelled by fletching material and so never match by name.
+ *  3. Anything left unaccounted for is kept, so a page that labels by material rather
+ *     than by version comes back whole.
+ *
+ * Step 2 can legitimately empty the list, and that is an answer rather than a failure:
+ * `Abyssal dagger` documents only the three poisoning recipes, so the plain dagger — a
+ * drop, not a craft — has no recipe on the page at all. It was being given the cheapest
+ * poisoning recipe instead, which put a 399gp cost on a 2.2M item and floated it to the
+ * top of the ROI sort. An empty result only happens when *every* method is claimed by a
+ * named sibling, so a page whose labels stop matching keeps everything rather than
+ * losing it.
+ * @param methods - Methods scraped from the page, in wiki order.
+ * @param version - The item's `wiki_version`, or null for an unversioned page.
+ * @param siblingVersions - Versions of the other items sharing this page.
+ * @returns The methods to store, in their original order; empty when the page documents
+ *   no recipe for this version.
+ */
+export function selectMethodsForVersion<T extends VariantLabelled>(
+    methods: T[],
+    version: string | null | undefined,
+    siblingVersions: Iterable<string> = [],
+): T[] {
+    const target = version ? normalizeVariantLabel(version) : '';
+    if (!target || !methods.length) return methods;
+
+    const labelOf = (method: T) => (method.methodName ? normalizeVariantLabel(method.methodName) : '');
+
+    const ownVariant = methods.filter((method) => labelOf(method) === target);
+    if (ownVariant.length) return ownVariant;
+
+    const siblings = new Set<string>();
+    for (const sibling of siblingVersions) {
+        const normalized = normalizeVariantLabel(sibling);
+        if (normalized && normalized !== target) siblings.add(normalized);
+    }
+    if (!siblings.size) return methods;
+
+    return methods.filter((method) => {
+        const label = labelOf(method);
+        return !label || !siblings.has(label);
+    });
+}

--- a/src/lib/helpers/wiki-page-title.test.ts
+++ b/src/lib/helpers/wiki-page-title.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'bun:test';
+import { deriveWikiPageIdentity, wikiTitleCandidates } from './wiki-page-title';
+
+describe('deriveWikiPageIdentity', () => {
+    it('splits an anchored wiki_url into page title and version', () => {
+        expect(
+            deriveWikiPageIdentity({
+                name: 'Oak seedling (w)',
+                wiki_name: 'Oak seedling (Watered)',
+                wiki_url: 'https://oldschool.runescape.wiki/w/Oak_seedling#Watered',
+            }),
+        ).toEqual({ wikiPageTitle: 'Oak seedling', wikiVersion: 'Watered' });
+    });
+
+    it('does not strip a parenthetical that is part of a real page title', () => {
+        // "Longbow (u)" is genuinely the page name — there is no anchor to key off,
+        // so the title must survive untouched.
+        expect(
+            deriveWikiPageIdentity({
+                name: 'Longbow (u)',
+                wiki_name: 'Longbow (u)',
+                wiki_url: 'https://oldschool.runescape.wiki/w/Longbow_(u)',
+            }),
+        ).toEqual({ wikiPageTitle: 'Longbow (u)', wikiVersion: null });
+    });
+
+    it('handles a page title that is parenthetical AND versioned', () => {
+        expect(
+            deriveWikiPageIdentity({
+                name: 'Holy grail',
+                wiki_name: 'Holy grail (item) (Normal)',
+                wiki_url: 'https://oldschool.runescape.wiki/w/Holy_grail_(item)#Normal',
+            }),
+        ).toEqual({ wikiPageTitle: 'Holy grail (item)', wikiVersion: 'Normal' });
+    });
+
+    it('percent-decodes before converting underscores to spaces', () => {
+        expect(
+            deriveWikiPageIdentity({
+                name: "Hydra's eye",
+                wiki_name: "Hydra's eye",
+                wiki_url: 'https://oldschool.runescape.wiki/w/Hydra%27s_eye',
+            }),
+        ).toEqual({ wikiPageTitle: "Hydra's eye", wikiVersion: null });
+    });
+
+    it('keeps a dose anchor that is itself parenthesised', () => {
+        expect(
+            deriveWikiPageIdentity({
+                name: 'Waterskin(4)',
+                wiki_name: 'Waterskin (4)',
+                wiki_url: 'https://oldschool.runescape.wiki/w/Waterskin#(4)',
+            }),
+        ).toEqual({ wikiPageTitle: 'Waterskin', wikiVersion: '(4)' });
+    });
+
+    it('decodes an encoded anchor', () => {
+        expect(
+            deriveWikiPageIdentity({
+                name: 'Ring of recoil',
+                wiki_name: 'Ring of recoil (1 charge)',
+                wiki_url: 'https://oldschool.runescape.wiki/w/Ring_of_recoil#1_charge',
+            }),
+        ).toEqual({ wikiPageTitle: 'Ring of recoil', wikiVersion: '1 charge' });
+    });
+
+    it('falls back to wiki_name when wiki_url is missing', () => {
+        expect(deriveWikiPageIdentity({ name: 'Axe', wiki_name: 'Bronze axe', wiki_url: null })).toEqual({
+            wikiPageTitle: 'Bronze axe',
+            wikiVersion: null,
+        });
+    });
+
+    it('falls back to name when both wiki fields are missing', () => {
+        expect(deriveWikiPageIdentity({ name: 'Bronze axe' })).toEqual({
+            wikiPageTitle: 'Bronze axe',
+            wikiVersion: null,
+        });
+    });
+
+    it('returns nulls when there is nothing to derive from', () => {
+        expect(deriveWikiPageIdentity({})).toEqual({ wikiPageTitle: null, wikiVersion: null });
+    });
+
+    it('ignores an empty anchor', () => {
+        expect(
+            deriveWikiPageIdentity({
+                name: 'Bronze axe',
+                wiki_url: 'https://oldschool.runescape.wiki/w/Bronze_axe#',
+            }),
+        ).toEqual({ wikiPageTitle: 'Bronze axe', wikiVersion: null });
+    });
+
+    it('keeps slashes that are part of the title', () => {
+        // MediaWiki titles may contain literal slashes, so the path cannot simply be
+        // split on '/' and reduced to its last segment.
+        expect(
+            deriveWikiPageIdentity({
+                name: '4/5ths full bucket',
+                wiki_name: '4/5ths full bucket',
+                wiki_url: 'https://oldschool.runescape.wiki/w/4/5ths_full_bucket',
+            }),
+        ).toEqual({ wikiPageTitle: '4/5ths full bucket', wikiVersion: null });
+    });
+
+    it('keeps slashes in a title that is also versioned', () => {
+        expect(
+            deriveWikiPageIdentity({
+                name: 'Dragon legs/skirt ornament kit',
+                wiki_name: 'Dragon legs/skirt ornament kit (Legs)',
+                wiki_url: 'https://oldschool.runescape.wiki/w/Dragon_legs/skirt_ornament_kit#Legs',
+            }),
+        ).toEqual({ wikiPageTitle: 'Dragon legs/skirt ornament kit', wikiVersion: 'Legs' });
+    });
+
+    it('tolerates a malformed percent-escape rather than throwing', () => {
+        expect(
+            deriveWikiPageIdentity({
+                name: 'Broken',
+                wiki_url: 'https://oldschool.runescape.wiki/w/100%_broken',
+            }),
+        ).toEqual({ wikiPageTitle: '100% broken', wikiVersion: null });
+    });
+});
+
+describe('wikiTitleCandidates', () => {
+    it('puts the real page title ahead of the synthetic wiki_name', () => {
+        expect(
+            wikiTitleCandidates({
+                name: 'Oak seedling (w)',
+                wiki_name: 'Oak seedling (Watered)',
+                wiki_url: 'https://oldschool.runescape.wiki/w/Oak_seedling#Watered',
+            }),
+        ).toEqual(['Oak seedling', 'Oak seedling (w)', 'Oak seedling (Watered)']);
+    });
+
+    it('deduplicates when the fields agree', () => {
+        expect(
+            wikiTitleCandidates({
+                name: 'Bronze axe',
+                wiki_name: 'Bronze axe',
+                wiki_url: 'https://oldschool.runescape.wiki/w/Bronze_axe',
+            }),
+        ).toEqual(['Bronze axe']);
+    });
+
+    it('returns an empty list when nothing is known', () => {
+        expect(wikiTitleCandidates({})).toEqual([]);
+    });
+});

--- a/src/lib/helpers/wiki-page-title.ts
+++ b/src/lib/helpers/wiki-page-title.ts
@@ -1,0 +1,126 @@
+/**
+ * Recovers the real OSRS Wiki page title for an item.
+ *
+ * OSRSBox does not store the page title for items that live on a "switch infobox"
+ * page. It synthesises `wiki_name` by appending the infobox version label in
+ * parentheses and points `wiki_url` at an anchor:
+ *
+ *   name      = "Oak seedling (w)"        <- the in-game name
+ *   wiki_name = "Oak seedling (Watered)"  <- synthetic; 404s on the wiki
+ *   wiki_url  = ".../w/Oak_seedling#Watered"
+ *
+ * Roughly 8,300 of the ~28,700 items in the dataset are shaped this way, so anything
+ * that scrapes the wiki by `wiki_name` silently misses all of them.
+ *
+ * `wiki_url` is the authoritative source: the page title is the part before the `#`
+ * and the version is the part after it. Deriving from the URL rather than
+ * regex-stripping `wiki_name` matters, because ~4,300 items have a parenthetical that
+ * is genuinely part of the page title ("Longbow (u)", "Holy grail (item)") and must
+ * survive intact.
+ *
+ * See `scripts/WIKI-NAME-NORMALIZATION.md` for the full analysis.
+ */
+
+/** An item's wiki fields, as stored on the OSRSBox item document. */
+export interface WikiNamedItem {
+    name?: string | null;
+    wiki_name?: string | null;
+    wiki_url?: string | null;
+}
+
+/** The real page title plus the infobox version it was anchored to, if any. */
+export interface WikiPageIdentity {
+    /** A page title that can actually be fetched from the wiki, e.g. "Oak seedling". */
+    wikiPageTitle: string | null;
+    /** The infobox version label, e.g. "Watered". Null when the page has no variants. */
+    wikiVersion: string | null;
+}
+
+/**
+ * Percent-decodes a URL segment, then converts wiki underscores to spaces.
+ *
+ * Order matters: decoding first means an encoded underscore is treated the same as a
+ * literal one, which is how MediaWiki resolves titles.
+ */
+function decodeWikiSegment(segment: string): string {
+    let decoded: string;
+
+    try {
+        decoded = decodeURIComponent(segment);
+    } catch {
+        // A stray '%' that isn't a valid escape (e.g. "100%_broken") throws; the raw
+        // segment is still a better answer than nothing.
+        decoded = segment;
+    }
+
+    return decoded.replace(/_/g, ' ').trim();
+}
+
+/**
+ * Strips the wiki's article-path prefix, leaving the raw page title.
+ *
+ * The title itself may contain slashes ("Dragon legs/skirt ornament kit"), so only the
+ * known `/w/` (or `/wiki/`) prefix is removed rather than splitting on every slash.
+ */
+function stripArticlePath(pagePart: string): string {
+    const articlePath = pagePart.match(/\/(?:w|wiki)\/(.+)$/);
+    if (articlePath) return articlePath[1];
+
+    // Not a recognised wiki URL — fall back to the segment after the last slash.
+    return pagePart.split('/').filter(Boolean).pop() ?? '';
+}
+
+/**
+ * Derives the fetchable wiki page title and version label for an item.
+ * @param item - The item's `name` / `wiki_name` / `wiki_url` fields.
+ * @returns The real page title and version label, either of which may be null.
+ */
+export function deriveWikiPageIdentity(item: WikiNamedItem): WikiPageIdentity {
+    const wikiUrl = item.wiki_url?.trim();
+
+    if (wikiUrl) {
+        const [pagePart, ...anchorParts] = wikiUrl.split('#');
+        const anchor = anchorParts.join('#');
+
+        const titleSegment = stripArticlePath(pagePart);
+
+        if (titleSegment) {
+            const wikiPageTitle = decodeWikiSegment(titleSegment);
+            const wikiVersion = anchor ? decodeWikiSegment(anchor) || null : null;
+
+            if (wikiPageTitle) return { wikiPageTitle, wikiVersion };
+        }
+    }
+
+    const fallback = item.wiki_name?.trim() || item.name?.trim();
+
+    return { wikiPageTitle: fallback || null, wikiVersion: null };
+}
+
+/**
+ * Builds an ordered, deduplicated list of titles to try when scraping the wiki.
+ *
+ * The derived page title goes first because it is the only one guaranteed to resolve.
+ * The in-game name comes next (it is usually a redirect, e.g. "Oak seedling (w)"), and
+ * the synthetic `wiki_name` is kept last as a final fallback for the handful of items
+ * where it happens to be the real title.
+ * @param item - The item's `name` / `wiki_name` / `wiki_url` fields.
+ * @returns Candidate page titles, most reliable first.
+ */
+export function wikiTitleCandidates(item: WikiNamedItem): string[] {
+    const { wikiPageTitle } = deriveWikiPageIdentity(item);
+    const ordered = [wikiPageTitle, item.name?.trim(), item.wiki_name?.trim()];
+
+    const seen = new Set<string>();
+    const candidates: string[] = [];
+
+    for (const candidate of ordered) {
+        if (!candidate) continue;
+        const key = candidate.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        candidates.push(candidate);
+    }
+
+    return candidates;
+}

--- a/src/lib/models/account-type.test.ts
+++ b/src/lib/models/account-type.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test';
+import {
+    accountTypeOptions,
+    canUseGrandExchange,
+    getAccountTypeOption,
+    isIronmanAccount,
+    normalizeAccountType,
+} from './account-type';
+import { CharacterProfile } from './player-stats';
+
+describe('normalizeAccountType', () => {
+    it('keeps every recognised account type', () => {
+        for (const option of accountTypeOptions) {
+            expect(normalizeAccountType(option.value)).toBe(option.value);
+        }
+    });
+
+    // Profiles saved before this field existed deserialize without it. They must read as mains so
+    // that adding the field does not silently change what an existing character is shown.
+    it('treats a profile with no account type as a main', () => {
+        expect(normalizeAccountType(undefined)).toBe('main');
+        expect(normalizeAccountType(null)).toBe('main');
+    });
+
+    it('rejects values that are not account types', () => {
+        expect(normalizeAccountType('IRONMAN')).toBe('main');
+        expect(normalizeAccountType('deadman')).toBe('main');
+        expect(normalizeAccountType(3)).toBe('main');
+        expect(normalizeAccountType({})).toBe('main');
+    });
+});
+
+describe('canUseGrandExchange', () => {
+    it('is true only for a main', () => {
+        expect(canUseGrandExchange('main')).toBe(true);
+    });
+
+    // Pricing branches on this one boolean so the Ironman variants cannot drift apart: they differ
+    // in bank and trading rules, not in which prices apply to them.
+    it('is false for every Ironman variant', () => {
+        for (const accountType of ['ironman', 'hardcore', 'ultimate', 'group'] as const) {
+            expect(canUseGrandExchange(accountType)).toBe(false);
+            expect(isIronmanAccount(accountType)).toBe(true);
+        }
+    });
+
+    it('falls back to Grand Exchange pricing when no character is selected', () => {
+        expect(canUseGrandExchange(undefined)).toBe(true);
+        expect(isIronmanAccount(undefined)).toBe(false);
+    });
+});
+
+describe('getAccountTypeOption', () => {
+    it('describes each account type', () => {
+        expect(getAccountTypeOption('hardcore').label).toBe('Hardcore Ironman');
+        expect(getAccountTypeOption('hardcore').shortLabel).toBe('HCIM');
+        expect(getAccountTypeOption('main').description).toBe('Prices come from the Grand Exchange.');
+    });
+
+    it('falls back to the default for an unknown value', () => {
+        expect(getAccountTypeOption(undefined).value).toBe('main');
+    });
+
+    it('gives every Ironman variant the same pricing sentence', () => {
+        const pricingSentence = getAccountTypeOption('ironman').description;
+        expect(pricingSentence).toStartWith('No economy prices.');
+        for (const accountType of ['hardcore', 'ultimate', 'group'] as const) {
+            expect(getAccountTypeOption(accountType).description).toStartWith(pricingSentence);
+        }
+    });
+});
+
+describe('CharacterProfile', () => {
+    it('defaults a new character to main', () => {
+        expect(new CharacterProfile('Zezima').accountType).toBe('main');
+    });
+
+    it('keeps an account type it is given', () => {
+        expect(new CharacterProfile('Zezima', undefined, undefined, 'ultimate').accountType).toBe('ultimate');
+    });
+
+    // The constructor is the rehydration path for persisted profiles, so a junk value stored by an
+    // older build must not propagate into pricing decisions.
+    it('normalizes an unrecognised stored account type', () => {
+        expect(new CharacterProfile('Zezima', undefined, undefined, 'deadman' as never).accountType).toBe('main');
+    });
+});

--- a/src/lib/models/account-type.ts
+++ b/src/lib/models/account-type.ts
@@ -1,0 +1,108 @@
+/**
+ * Which game mode a character plays, and therefore which prices the app may show them.
+ *
+ * Ironman accounts cannot use the Grand Exchange, so every gp figure derived from GE prices is
+ * wrong for them on both sides of a recipe: they cannot buy the inputs and cannot sell the output.
+ * The mode lives on the character rather than on a page's preferences so that pricing follows the
+ * active character instead of disagreeing with itself between the browse page and an item page.
+ */
+export type AccountType = 'main' | 'ironman' | 'hardcore' | 'ultimate' | 'group';
+
+/** The default for a character that predates this field, so saved profiles keep today's behaviour. */
+export const DEFAULT_ACCOUNT_TYPE: AccountType = 'main';
+
+const ACCOUNT_TYPES: readonly AccountType[] = ['main', 'ironman', 'hardcore', 'ultimate', 'group'];
+
+/**
+ * How an account type is described where it is chosen.
+ * @property value       - The stored discriminator.
+ * @property label       - The account type's in-game name.
+ * @property shortLabel  - Compact form for the character-switcher badge.
+ * @property description - What picking it changes about the prices shown.
+ */
+export type AccountTypeOption = {
+    value: AccountType;
+    label: string;
+    shortLabel: string;
+    description: string;
+};
+
+const IRONMAN_PRICING_COPY =
+    'No economy prices. Prices are shown using alchemy and base shop values (e.g. before the shop ' +
+    'value of an item drops from selling multiple).';
+
+export const accountTypeOptions: readonly AccountTypeOption[] = [
+    {
+        value: 'main',
+        label: 'Main',
+        shortLabel: 'Main',
+        description: 'Prices come from the Grand Exchange.',
+    },
+    {
+        value: 'ironman',
+        label: 'Ironman',
+        shortLabel: 'Ironman',
+        description: IRONMAN_PRICING_COPY,
+    },
+    {
+        value: 'hardcore',
+        label: 'Hardcore Ironman',
+        shortLabel: 'HCIM',
+        description: IRONMAN_PRICING_COPY,
+    },
+    {
+        value: 'ultimate',
+        label: 'Ultimate Ironman',
+        shortLabel: 'UIM',
+        description: `${IRONMAN_PRICING_COPY} No bank.`,
+    },
+    {
+        value: 'group',
+        label: 'Group Ironman',
+        shortLabel: 'GIM',
+        description: `${IRONMAN_PRICING_COPY} Trading is limited to your group.`,
+    },
+];
+
+/**
+ * Coerces an unknown stored value into a usable account type.
+ *
+ * Profiles saved before this field existed have no value at all, so anything unrecognised becomes
+ * `main` and those characters see exactly what they saw before.
+ * @param value - The value read from a persisted profile.
+ * @returns A valid account type.
+ */
+export function normalizeAccountType(value?: unknown): AccountType {
+    return ACCOUNT_TYPES.includes(value as AccountType) ? (value as AccountType) : DEFAULT_ACCOUNT_TYPE;
+}
+
+/**
+ * Whether an account may trade on the Grand Exchange, and so whether GE prices mean anything to it.
+ *
+ * Every pricing decision branches on this rather than on the account type itself, so the four
+ * Ironman variants cannot drift apart. They differ in bank and trading rules, not in pricing.
+ * @param accountType - The character's account type, or nothing when no character is selected.
+ * @returns True for mains and for a missing character; false for every Ironman variant.
+ */
+export function canUseGrandExchange(accountType?: AccountType | null): boolean {
+    return normalizeAccountType(accountType) === 'main';
+}
+
+/**
+ * Whether an account should be shown Ironman pricing. The inverse of {@link canUseGrandExchange}.
+ * @param accountType - The character's account type, or nothing when no character is selected.
+ * @returns True for every Ironman variant.
+ */
+export function isIronmanAccount(accountType?: AccountType | null): boolean {
+    return !canUseGrandExchange(accountType);
+}
+
+/**
+ * Looks up how an account type is presented.
+ * @param accountType - The character's account type.
+ * @returns The matching option, falling back to the default account type's.
+ */
+export function getAccountTypeOption(accountType?: AccountType | null): AccountTypeOption {
+    const normalized = normalizeAccountType(accountType);
+    return accountTypeOptions.find((option) => option.value === normalized) ?? accountTypeOptions[0];
+}

--- a/src/lib/models/game-item.ts
+++ b/src/lib/models/game-item.ts
@@ -69,6 +69,7 @@ export type IGameItem = {
         creationCost?: number | null;
         creationProfit?: number | null;
         creationRoi?: number | null;
+        ironmanExitValue?: number | null;
     };
 
 /**

--- a/src/lib/models/mongo-schemas/osrsbox-db-item-schema.ts
+++ b/src/lib/models/mongo-schemas/osrsbox-db-item-schema.ts
@@ -109,6 +109,8 @@ export const osrsboxItemSchema: Schema<OsrsboxItemDocument> = new Schema(
         icon: { type: String, required: true },
         wiki_name: { type: String, default: null },
         wiki_url: { type: String, default: null },
+        wiki_page_title: { type: String, default: null },
+        wiki_version: { type: String, default: null },
         equipment: { type: Schema.Types.Mixed, default: null },
         weapon: { type: Schema.Types.Mixed, default: null },
         highPrice: { type: Number, required: false },

--- a/src/lib/models/osrsbox-db-item.ts
+++ b/src/lib/models/osrsbox-db-item.ts
@@ -78,6 +78,8 @@ export type GameItemCreationSpecs = {
  * @property icon - Item icon encoded as base64. Required; not nullable.
  * @property wiki_name - OSRS Wiki display name. Required; nullable.
  * @property wiki_url - OSRS Wiki URL (may include anchor link). Required; nullable.
+ * @property wiki_page_title - Real, fetchable wiki page title derived from `wiki_url`. Nullable.
+ * @property wiki_version - Infobox version label the item corresponds to, e.g. "Watered". Nullable.
  * @property equipment - Equipment bonuses of equipable armour/weapons. Required; nullable.
  * @property weapon - Weapon bonuses including attack speed, type and stance. Required; nullable.
  */
@@ -112,6 +114,8 @@ export interface IOsrsboxItem {
     icon: string;
     wiki_name: string | null;
     wiki_url: string | null;
+    wiki_page_title?: string | null;
+    wiki_version?: string | null;
     equipment: Record<string, unknown> | null;
     weapon: Record<string, unknown> | null;
     creationSpecs?: GameItemCreationSpecs[];

--- a/src/lib/models/player-stats.ts
+++ b/src/lib/models/player-stats.ts
@@ -1,32 +1,40 @@
 import { v4 as uuidv4 } from 'uuid';
 import { SkillNames } from '$lib/constants/enums/skill-names';
 import { defaultSkillLevels } from '$lib/constants/default-skill-levels';
+import { DEFAULT_ACCOUNT_TYPE, normalizeAccountType, type AccountType } from '$lib/models/account-type';
 import type { UUID } from 'crypto';
 
 /**
  * The shape of the stat data kept on a player character.
  * @property id           - The randomly-generated ID of the character for referencing in localStorage.
  * @property name         - The name of the character.
+ * @property accountType  - Which game mode the character plays, which decides how prices are shown.
  * @property skillLevels  - Record relating skill levels to their respective level numbers.
  */
 export interface ICharacterProfile {
     id: UUID;
     name: string;
+    accountType: AccountType;
     skillLevels: Record<SkillNames, number>;
 }
 
 export class CharacterProfile implements ICharacterProfile {
     id: ICharacterProfile['id'];
     name: ICharacterProfile['name'];
+    accountType: ICharacterProfile['accountType'];
     skillLevels: ICharacterProfile['skillLevels'];
 
     constructor(
         name: ICharacterProfile['name'],
         skillLevels: ICharacterProfile['skillLevels'] = defaultSkillLevels,
         id?: ICharacterProfile['id'],
+        accountType: ICharacterProfile['accountType'] = DEFAULT_ACCOUNT_TYPE,
     ) {
         this.id = id || (uuidv4() as UUID);
         this.name = name;
+        // Profiles persisted before this field existed deserialize with it missing, so normalize
+        // rather than trusting the argument: an absent account type must read as a main.
+        this.accountType = normalizeAccountType(accountType);
         this.skillLevels = { ...defaultSkillLevels, ...skillLevels };
     }
 }

--- a/src/lib/services/game-item-creation-cost.test.ts
+++ b/src/lib/services/game-item-creation-cost.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Integration coverage for the creation-cost half of the profit/ROI pipeline.
+ *
+ * Runs against a real MongoDB so the aggregation is executed by the server rather
+ * than asserted by inspection. Set TEST_MONGO_URI to point at a throwaway instance:
+ *
+ *   docker run -d --rm -p 27018:27017 mongo:7
+ *   TEST_MONGO_URI=mongodb://127.0.0.1:27018 bun test
+ *
+ * Skipped automatically when no such instance is reachable.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import mongoose from 'mongoose';
+
+const TEST_MONGO_URI = process.env.TEST_MONGO_URI ?? 'mongodb://127.0.0.1:27018';
+
+/** Probes for a usable Mongo before declaring the suite. */
+async function mongoReachable(): Promise<boolean> {
+    try {
+        await mongoose.connect(TEST_MONGO_URI, { dbName: 'ge-skiller-test', serverSelectionTimeoutMS: 1500 });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+const reachable = await mongoReachable();
+const describeIfMongo = reachable ? describe : describe.skip;
+
+if (!reachable) {
+    console.warn(`[creation-cost] Skipping: no MongoDB at ${TEST_MONGO_URI}`);
+}
+
+describeIfMongo('creation cost for untradeable ingredients', () => {
+    let OsrsboxItemModel: typeof import('$lib/models/mongo-schemas/osrsbox-db-item-schema').OsrsboxItemModel;
+    let getPaginatedGameItems: typeof import('./game-item-mongo-service.server').getPaginatedGameItems;
+
+    // Minimal item shape satisfying the schema's required fields.
+    const baseItem = {
+        last_updated: '2026-01-01',
+        incomplete: false,
+        members: true,
+        tradeable: true,
+        stackable: false,
+        stacked: null,
+        noted: false,
+        noteable: true,
+        linked_id_item: null,
+        linked_id_noted: null,
+        linked_id_placeholder: null,
+        placeholder: false,
+        equipable: false,
+        equipable_by_player: false,
+        equipable_weapon: false,
+        quest_item: false,
+        duplicate: false,
+        icon: 'x',
+    };
+
+    const seedlingObjectId = new mongoose.Types.ObjectId();
+
+    beforeAll(async () => {
+        ({ OsrsboxItemModel } = await import('$lib/models/mongo-schemas/osrsbox-db-item-schema'));
+        ({ getPaginatedGameItems } = await import('./game-item-mongo-service.server'));
+
+        await OsrsboxItemModel.deleteMany({});
+        await OsrsboxItemModel.insertMany([
+            {
+                ...baseItem,
+                _id: seedlingObjectId,
+                id: 5364,
+                name: 'Oak seedling (w)',
+                // Untradeable: no market price, and `cost` is a meaningless base value.
+                tradeable: false,
+                tradeable_on_ge: false,
+                cost: 1,
+            },
+            {
+                ...baseItem,
+                id: 5370,
+                name: 'Oak sapling',
+                tradeable_on_ge: true,
+                cost: 1,
+                highPrice: 316,
+                creationSpecs: [
+                    {
+                        experienceGranted: [],
+                        requiredSkills: [],
+                        ingredients: [{ item: seedlingObjectId, amount: 1, consumedDuringCreation: true }],
+                    },
+                ],
+            },
+        ]);
+    });
+
+    afterAll(async () => {
+        await OsrsboxItemModel.deleteMany({});
+        await mongoose.disconnect();
+    });
+
+    it('does not invent a 1gp cost from an untradeable ingredient', async () => {
+        const page = await getPaginatedGameItems({ page: 1, perPage: 10, sortOrder: 'desc', profitMode: true });
+        const sapling = page.items.find((item) => item.name === 'Oak sapling') as Record<string, unknown> | undefined;
+
+        expect(sapling).toBeDefined();
+        // Previously this was 1, making profit 315 and ROI 31500%.
+        expect(sapling!.creationCost ?? null).toBeNull();
+        expect(sapling!.creationProfit ?? null).toBeNull();
+    });
+
+    it('keeps items with an unknown creation cost out of the ROI sort', async () => {
+        const page = await getPaginatedGameItems({ page: 1, perPage: 10, sortOrder: 'roi-desc' });
+        expect(page.items.some((item) => item.name === 'Oak sapling')).toBe(false);
+    });
+
+    it('still prices a tradeable ingredient from cost when it has no live GE price', async () => {
+        await OsrsboxItemModel.updateOne({ _id: seedlingObjectId }, { $set: { tradeable_on_ge: true, cost: 40 } });
+
+        const page = await getPaginatedGameItems({ page: 1, perPage: 10, sortOrder: 'desc', profitMode: true });
+        const sapling = page.items.find((item) => item.name === 'Oak sapling') as Record<string, unknown> | undefined;
+
+        expect(sapling!.creationCost).toBe(40);
+        expect(sapling!.creationProfit).toBe(276);
+
+        await OsrsboxItemModel.updateOne({ _id: seedlingObjectId }, { $set: { tradeable_on_ge: false, cost: 1 } });
+    });
+});

--- a/src/lib/services/game-item-creation-cost.test.ts
+++ b/src/lib/services/game-item-creation-cost.test.ts
@@ -58,6 +58,7 @@ describeIfMongo('creation cost for untradeable ingredients', () => {
     };
 
     const seedlingObjectId = new mongoose.Types.ObjectId();
+    const coinsObjectId = new mongoose.Types.ObjectId();
 
     beforeAll(async () => {
         ({ OsrsboxItemModel } = await import('$lib/models/mongo-schemas/osrsbox-db-item-schema'));
@@ -90,6 +91,32 @@ describeIfMongo('creation cost for untradeable ingredients', () => {
                     },
                 ],
             },
+            {
+                ...baseItem,
+                _id: coinsObjectId,
+                id: 995,
+                name: 'Coins',
+                // Coins carry the untradeable flag but their cost is a literal gp price.
+                tradeable: false,
+                tradeable_on_ge: false,
+                stackable: true,
+                cost: 1,
+            },
+            {
+                ...baseItem,
+                id: 113,
+                name: 'Strength potion(4)',
+                tradeable_on_ge: true,
+                cost: 1,
+                highPrice: 500,
+                creationSpecs: [
+                    {
+                        experienceGranted: [],
+                        requiredSkills: [],
+                        ingredients: [{ item: coinsObjectId, amount: 5, consumedDuringCreation: true }],
+                    },
+                ],
+            },
         ]);
     });
 
@@ -106,6 +133,17 @@ describeIfMongo('creation cost for untradeable ingredients', () => {
         // Previously this was 1, making profit 315 and ROI 31500%.
         expect(sapling!.creationCost ?? null).toBeNull();
         expect(sapling!.creationProfit ?? null).toBeNull();
+    });
+
+    it('still prices a coin fee, which is untradeable but is literally gp', async () => {
+        const page = await getPaginatedGameItems({ page: 1, perPage: 10, sortOrder: 'desc', profitMode: true });
+        const potion = page.items.find((item) => item.name === 'Strength potion(4)') as
+            | Record<string, unknown>
+            | undefined;
+
+        expect(potion).toBeDefined();
+        expect(potion!.creationCost).toBe(5);
+        expect(potion!.creationProfit).toBe(495);
     });
 
     it('keeps items with an unknown creation cost out of the ROI sort', async () => {

--- a/src/lib/services/game-item-mongo-service.server.ts
+++ b/src/lib/services/game-item-mongo-service.server.ts
@@ -2,6 +2,7 @@ import { Types } from 'mongoose';
 import { skillTreeSlugs } from '$lib/constants/skill-tree-pages';
 import { MAX_ITEM_TREE_DEPTH, MAX_ITEM_TREE_NODES } from '$lib/constants/item-tree';
 import { OsrsboxItemModel, type OsrsboxItemDocument } from '$lib/models/mongo-schemas/osrsbox-db-item-schema';
+import { NATURE_RUNE_FALLBACK_PRICE, NATURE_RUNE_ITEM_ID } from '$lib/constants/alchemy';
 import type { IOsrsboxItemWithMeta } from '$lib/models/osrsbox-db-item';
 import { currencyItemNames } from '$lib/helpers/ingredient-price';
 
@@ -10,6 +11,8 @@ type GameItemDoc = OsrsboxItemDocument & {
     creationCost?: number | null;
     creationProfit?: number | null;
     creationRoi?: number | null;
+    /** What the item is realistically worth to an account that cannot trade. Ironman mode only. */
+    ironmanExitValue?: number | null;
 };
 const MAX_INGREDIENT_DEPTH = MAX_ITEM_TREE_DEPTH;
 
@@ -23,6 +26,37 @@ const LEGACY_SORT_ORDERS: Record<string, GameItemSortOrder> = {
 };
 export type PlayerSkillLevels = Record<string, number>;
 export type PlayerSupplies = Record<string, number>;
+
+/**
+ * The live nature rune price, cached briefly.
+ *
+ * Every Ironman valuation is net of the rune an alchemy cast burns, so this is read once and reused
+ * across the documents in a request rather than hardcoded — a fixed gp figure goes stale as soon as
+ * the market moves. A failed read falls back to the documented default rather than pricing the rune
+ * at zero, which would overstate every value on the page.
+ */
+let natureRunePriceCache: { price: number; readAt: number } | null = null;
+const NATURE_RUNE_CACHE_MS = 5 * 60 * 1000;
+
+async function getNatureRunePrice(): Promise<number> {
+    if (natureRunePriceCache && Date.now() - natureRunePriceCache.readAt < NATURE_RUNE_CACHE_MS) {
+        return natureRunePriceCache.price;
+    }
+
+    try {
+        const rune = await OsrsboxItemModel.findOne({ id: NATURE_RUNE_ITEM_ID })
+            .select({ highPrice: 1, lowPrice: 1 })
+            .lean<{ highPrice?: number; lowPrice?: number }>()
+            .exec();
+
+        const price = rune?.highPrice ?? rune?.lowPrice ?? null;
+        const resolved = typeof price === 'number' && price > 0 ? price : NATURE_RUNE_FALLBACK_PRICE;
+        natureRunePriceCache = { price: resolved, readAt: Date.now() };
+        return resolved;
+    } catch {
+        return NATURE_RUNE_FALLBACK_PRICE;
+    }
+}
 
 export type PaginatedGameItems = {
     items: GameItemDoc[];
@@ -333,8 +367,9 @@ export async function getPaginatedGameItems(params?: {
     // cost — and with it their ROI — is zero for every survivor. Filtering on ROI as well would
     // leave nothing at all, so skip it there and let the sort fall through to profit instead.
     const filterMissingRoi = roiSort && !enforceSupplies;
+    const natureRunePrice = ironman && shouldComputeProfit ? await getNatureRunePrice() : NATURE_RUNE_FALLBACK_PRICE;
     const profitStages = shouldComputeProfit
-        ? buildProfitPipeline(supplyMap, profitDrivenSort, enforceSupplies, filterMissingRoi)
+        ? buildProfitPipeline(supplyMap, profitDrivenSort, enforceSupplies, filterMissingRoi, ironman, natureRunePrice)
         : [];
     const supplyStages = !profitDrivenSort && suppliesFilterActive ? buildSuppliesFilterPipeline(supplyMap) : [];
     // Profit only needs to be computed for every candidate when it drives the sort order;
@@ -517,11 +552,13 @@ function normalizeSupplies(supplies?: PlayerSupplies | null): PlayerSupplies | n
     return Object.fromEntries(entries);
 }
 
-function buildProfitPipeline(
+export function buildProfitPipeline(
     supplies?: PlayerSupplies | null,
     filterMissingProfit: boolean = false,
     enforceSupplies: boolean = false,
     filterMissingRoi: boolean = false,
+    ironman: boolean = false,
+    natureRunePrice: number = NATURE_RUNE_FALLBACK_PRICE,
 ): Record<string, unknown>[] {
     const supplyMap = supplies ?? normalizeSupplies(supplies);
     const hasSupplies = enforceSupplies || Boolean(supplyMap);
@@ -553,7 +590,7 @@ function buildProfitPipeline(
     const costIsPriceExpr = {
         $or: [{ $eq: ['$$matched.tradeable_on_ge', true] }, { $in: ['$$matched.name', currencyItemNames] }],
     };
-    const unitPriceExpr = {
+    const geUnitPriceExpr = {
         $ifNull: [
             '$$matched.highPrice',
             {
@@ -561,7 +598,37 @@ function buildProfitPipeline(
             },
         ],
     };
-    const outputPriceExpr = { $ifNull: ['$highPrice', { $ifNull: ['$lowPrice', '$cost'] }] };
+    const geOutputPriceExpr = { $ifNull: ['$highPrice', { $ifNull: ['$lowPrice', '$cost'] }] };
+
+    /**
+     * What an item is worth to an account that cannot trade, as an aggregation expression.
+     *
+     * Mirrors `resolveIronmanUnitValue` so the browse list, the item page and the cost table all
+     * agree. Alchemy net of the nature rune is the value; currency keeps its `cost` because coins
+     * are money; anything the app cannot value stays null so it drops out of the ROI sort rather
+     * than ranking on an invented number.
+     */
+    const ironmanValueExpr = (alchField: string, nameField: string, costField: string) => ({
+        $cond: [
+            { $in: [nameField, currencyItemNames] },
+            { $ifNull: [costField, null] },
+            {
+                $cond: [
+                    { $gt: [{ $ifNull: [alchField, 0] }, 0] },
+                    { $max: [0, { $subtract: [alchField, natureRunePrice] }] },
+                    null,
+                ],
+            },
+        ],
+    });
+
+    // Ironman mode swaps what both sides of the recipe are priced at, not just what is displayed.
+    // Leaving these on Grand Exchange prices is what made the browse ranking identical in both
+    // modes: the numbers on the cards changed, the order they came back in did not.
+    const unitPriceExpr = ironman
+        ? ironmanValueExpr('$$matched.highalch', '$$matched.name', '$$matched.cost')
+        : geUnitPriceExpr;
+    const outputPriceExpr = ironman ? ironmanValueExpr('$highalch', '$name', '$cost') : geOutputPriceExpr;
     const ingredientCostRowsExpr = {
         $map: {
             input: '$consumedIngredients',
@@ -684,7 +751,18 @@ function buildProfitPipeline(
                 localField: 'consumedIngredientIds',
                 foreignField: '_id',
                 pipeline: [
-                    { $project: { _id: 1, id: 1, name: 1, highPrice: 1, lowPrice: 1, cost: 1, tradeable_on_ge: 1 } },
+                    {
+                        $project: {
+                            _id: 1,
+                            id: 1,
+                            name: 1,
+                            highPrice: 1,
+                            lowPrice: 1,
+                            cost: 1,
+                            highalch: 1,
+                            tradeable_on_ge: 1,
+                        },
+                    },
                 ],
                 as: 'ingredientItems',
             },
@@ -703,7 +781,11 @@ function buildProfitPipeline(
                 creationProfit: {
                     $cond: [
                         {
-                            $and: [{ $gt: ['$outputPrice', 0] }, { $ne: ['$creationCost', null] }],
+                            $and: [
+                                { $ne: ['$outputPrice', null] },
+                                { $gt: ['$outputPrice', 0] },
+                                { $ne: ['$creationCost', null] },
+                            ],
                         },
                         { $subtract: ['$outputPrice', '$creationCost'] },
                         null,
@@ -739,6 +821,12 @@ function buildProfitPipeline(
 
     if (enforceSupplies && hasSupplies) {
         pipeline.push({ $match: { $expr: suppliesSatisfiedExpr } });
+    }
+
+    if (ironman) {
+        // The card's headline number. Kept as its own field rather than reusing `outputPrice`,
+        // which is scratch state the $unset below clears.
+        pipeline.push({ $set: { ironmanExitValue: '$outputPrice' } });
     }
 
     pipeline.push({

--- a/src/lib/services/game-item-mongo-service.server.ts
+++ b/src/lib/services/game-item-mongo-service.server.ts
@@ -26,6 +26,30 @@ export type PaginatedGameItems = {
 };
 
 /**
+ * The fields the ingredient tree is actually read for.
+ *
+ * A tree node is a whole OSRSBox document by default, and most of that document — combat
+ * bonuses, wiki links, release dates, linked ids — is never rendered. Sending it anyway
+ * cost roughly 40% of a payload that already reaches 1.5MB on the worst items, multiplied
+ * by every repeated node. `tradeable_on_ge` and `name` are here for
+ * `resolveIngredientUnitPrice`, which the cost table applies per row.
+ */
+const TREE_NODE_PROJECTION = {
+    _id: 1,
+    id: 1,
+    name: 1,
+    icon: 1,
+    examine: 1,
+    highPrice: 1,
+    lowPrice: 1,
+    highalch: 1,
+    lowalch: 1,
+    cost: 1,
+    tradeable_on_ge: 1,
+    creationSpecs: 1,
+} as const;
+
+/**
  * Populates nested ingredient trees so the frontend can render a full org chart.
  */
 export async function populateIngredientsTree(itemId: string): Promise<IOsrsboxItemWithMeta | null> {
@@ -41,7 +65,7 @@ export async function populateIngredientsTree(itemId: string): Promise<IOsrsboxI
         query.id = trimmedId;
     }
 
-    const root = await OsrsboxItemModel.findOne(query)
+    const root = await OsrsboxItemModel.findOne(query, TREE_NODE_PROJECTION)
         .lean<IOsrsboxItemWithMeta & { _id: Types.ObjectId }>()
         .exec();
     if (!root) return null;
@@ -54,7 +78,10 @@ export async function populateIngredientsTree(itemId: string): Promise<IOsrsboxI
         const missing = Array.from(new Set(frontier)).filter((id) => !cache.has(id));
         if (!missing.length) break;
 
-        const docs = await OsrsboxItemModel.find({ _id: { $in: missing.map((id) => new Types.ObjectId(id)) } })
+        const docs = await OsrsboxItemModel.find(
+            { _id: { $in: missing.map((id) => new Types.ObjectId(id)) } },
+            TREE_NODE_PROJECTION,
+        )
             .lean<(IOsrsboxItemWithMeta & { _id: Types.ObjectId })[]>()
             .exec();
 

--- a/src/lib/services/game-item-mongo-service.server.ts
+++ b/src/lib/services/game-item-mongo-service.server.ts
@@ -276,6 +276,7 @@ export async function getPaginatedGameItems(params?: {
     supplies?: PlayerSupplies | null;
     suppliesActive?: boolean;
     profitMode?: boolean;
+    ironman?: boolean;
 }): Promise<PaginatedGameItems> {
     const page = Math.max(1, params?.page ?? 1);
     const perPage = Math.max(1, Math.min(200, params?.perPage ?? 12));
@@ -290,22 +291,31 @@ export async function getPaginatedGameItems(params?: {
     const profitMode = Boolean(params?.profitMode);
     const baseFilterQuery = getFilterQuery(filter);
     const skillQuery = getSkillMatchQuery(params?.skill);
+    const ironman = Boolean(params?.ironman);
     const filterQuery = mergeQueries(baseFilterQuery, skillQuery, {
         placeholder: false,
         noted: false,
         stacked: null,
-        tradeable_on_ge: true,
-        ...getValidPriceQuery(),
+        ...getVisibilityQuery(ironman),
     });
     const skillLevels = normalizeSkillLevels(params?.skillLevels);
     const suppliesActive = Boolean(params?.suppliesActive);
     const supplies = normalizeSupplies(params?.supplies);
     const supplyMap = supplies ?? (suppliesActive ? {} : null);
 
+    // Under Ironman an item's value can come from alchemy rather than the market, so `highalch` joins
+    // the sort keys. Every key here is a stored field, so this stays an index-eligible sort rather
+    // than a computed one — the profit pipeline is already the expensive path and must not grow.
+    // Annotated rather than inferred: a bare object literal widens its values to `number`, which
+    // Mongoose's `sort()` rejects because it wants the `SortOrder` literals.
+    const valueSortKeys: Record<string, 1 | -1> = ironman
+        ? { highPrice: sortDirection, highalch: sortDirection, cost: sortDirection, name: 1 }
+        : { highPrice: sortDirection, cost: sortDirection, name: 1 };
+
     if (!skillLevels && !profitDrivenSort && !profitMode && !suppliesActive && !supplies) {
         const [items, total] = await Promise.all([
             OsrsboxItemModel.find(filterQuery)
-                .sort({ highPrice: sortDirection, cost: sortDirection, name: 1 })
+                .sort(valueSortKeys)
                 .skip(skip)
                 .limit(perPage)
                 .lean<GameItemDoc[]>()
@@ -335,7 +345,7 @@ export async function getPaginatedGameItems(params?: {
         ? { creationRoi: sortDirection, creationProfit: -1, highPrice: -1, cost: -1, name: 1 }
         : roiValueSort
           ? { creationProfit: sortDirection, creationRoi: -1, highPrice: -1, cost: -1, name: 1 }
-          : { highPrice: sortDirection, cost: sortDirection, name: 1 };
+          : valueSortKeys;
 
     const [{ items, total = 0 } = { items: [], total: 0 }] = await OsrsboxItemModel.aggregate<{
         items: GameItemDoc[];
@@ -368,7 +378,11 @@ export async function getPaginatedGameItems(params?: {
 /**
  * Performs a simple text search across name and examine fields.
  */
-export async function searchGameItems(query: string, limit: number = 10): Promise<GameItemDoc[]> {
+export async function searchGameItems(
+    query: string,
+    limit: number = 10,
+    ironman: boolean = false,
+): Promise<GameItemDoc[]> {
     const sanitizedQuery = query.trim();
     if (!sanitizedQuery) return [];
 
@@ -383,8 +397,7 @@ export async function searchGameItems(query: string, limit: number = 10): Promis
         placeholder: false,
         noted: false,
         stacked: null,
-        tradeable_on_ge: true,
-        ...getValidPriceQuery(),
+        ...getVisibilityQuery(ironman),
     };
 
     async function fetchAndAppend(filter: Record<string, unknown>) {
@@ -441,9 +454,34 @@ function normalizeFilter(filter?: GameItemFilter): GameItemFilter {
     return allowed.includes(filter) ? filter : 'all';
 }
 
-function getValidPriceQuery(): Record<string, unknown> {
+/**
+ * Restricts results to items the reader can actually put a number against.
+ *
+ * A Grand Exchange price is the only value a main has, so for them an item without one is a row of
+ * dashes. An Ironman never had that price to begin with: alchemy values them instead, which is why
+ * `highalch` counts here. Shop prices join this list once they are scraped.
+ * @param ironman - Whether the reader is on an account that cannot use the Grand Exchange.
+ * @returns A query fragment requiring at least one usable value.
+ */
+function getValidPriceQuery(ironman = false): Record<string, unknown> {
+    const clauses: Record<string, unknown>[] = [{ highPrice: { $gt: 0 } }, { lowPrice: { $gt: 0 } }];
+    if (ironman) clauses.push({ highalch: { $gt: 0 } });
+    return { $or: clauses };
+}
+
+/**
+ * The tradeability and price gate shared by browsing and search.
+ *
+ * Untradeable items are excluded for a main because nothing in the app can price them. For an
+ * Ironman that exclusion hides a large share of what they actually make, so it is lifted and the
+ * alchemy fallback above carries the value.
+ * @param ironman - Whether the reader is on an account that cannot use the Grand Exchange.
+ * @returns A query fragment gating which items are visible.
+ */
+export function getVisibilityQuery(ironman = false): Record<string, unknown> {
     return {
-        $or: [{ highPrice: { $gt: 0 } }, { lowPrice: { $gt: 0 } }],
+        ...(ironman ? {} : { tradeable_on_ge: true }),
+        ...getValidPriceQuery(ironman),
     };
 }
 
@@ -501,9 +539,7 @@ function buildProfitPipeline(
               ],
           }
         : 0;
-    const neededExpr = hasSupplies
-        ? { $max: [0, { $subtract: ['$$amount', '$$supplyQty'] }] }
-        : '$$amount';
+    const neededExpr = hasSupplies ? { $max: [0, { $subtract: ['$$amount', '$$supplyQty'] }] } : '$$amount';
     // `cost` is the item's base game value, not a market price. Using it for an
     // ingredient that has no GE market — an untradeable intermediate such as
     // "Oak seedling (w)", whose cost is 1 — invented a 1gp outlay and sent the
@@ -515,10 +551,7 @@ function buildProfitPipeline(
     // third of all recipes charge a coin fee, and 5 coins really does cost 5gp. Mirrors
     // `resolveIngredientUnitPrice`, which prices the same rows on the item page.
     const costIsPriceExpr = {
-        $or: [
-            { $eq: ['$$matched.tradeable_on_ge', true] },
-            { $in: ['$$matched.name', currencyItemNames] },
-        ],
+        $or: [{ $eq: ['$$matched.tradeable_on_ge', true] }, { $in: ['$$matched.name', currencyItemNames] }],
     };
     const unitPriceExpr = {
         $ifNull: [
@@ -670,10 +703,7 @@ function buildProfitPipeline(
                 creationProfit: {
                     $cond: [
                         {
-                            $and: [
-                                { $gt: ['$outputPrice', 0] },
-                                { $ne: ['$creationCost', null] },
-                            ],
+                            $and: [{ $gt: ['$outputPrice', 0] }, { $ne: ['$creationCost', null] }],
                         },
                         { $subtract: ['$outputPrice', '$creationCost'] },
                         null,
@@ -953,7 +983,9 @@ function buildPlayerSkillMatchExpression(skillLevels: PlayerSkillLevels) {
                                                                                             field: {
                                                                                                 $toLower: '$$req.k',
                                                                                             },
-                                                                                            input: { $literal: skillLevels },
+                                                                                            input: {
+                                                                                                $literal: skillLevels,
+                                                                                            },
                                                                                         },
                                                                                     },
                                                                                     0,
@@ -989,7 +1021,9 @@ function buildPlayerSkillMatchExpression(skillLevels: PlayerSkillLevels) {
                                                                                                     ],
                                                                                                 },
                                                                                             },
-                                                                                            input: { $literal: skillLevels },
+                                                                                            input: {
+                                                                                                $literal: skillLevels,
+                                                                                            },
                                                                                         },
                                                                                     },
                                                                                     0,

--- a/src/lib/services/game-item-mongo-service.server.ts
+++ b/src/lib/services/game-item-mongo-service.server.ts
@@ -144,6 +144,7 @@ export async function getGameItemById(itemId: string): Promise<IOsrsboxItemWithM
             buy_limit: 1,
             wiki_name: 1,
             wiki_url: 1,
+            wiki_page_title: 1,
         })
         .lean<IOsrsboxItemWithMeta>()
         .exec();

--- a/src/lib/services/game-item-mongo-service.server.ts
+++ b/src/lib/services/game-item-mongo-service.server.ts
@@ -3,6 +3,7 @@ import { skillTreeSlugs } from '$lib/constants/skill-tree-pages';
 import { MAX_ITEM_TREE_DEPTH } from '$lib/constants/item-tree';
 import { OsrsboxItemModel, type OsrsboxItemDocument } from '$lib/models/mongo-schemas/osrsbox-db-item-schema';
 import type { IOsrsboxItemWithMeta } from '$lib/models/osrsbox-db-item';
+import { currencyItemNames } from '$lib/helpers/ingredient-price';
 
 type GameItemDoc = OsrsboxItemDocument & {
     _id: Types.ObjectId;
@@ -412,14 +413,21 @@ function buildProfitPipeline(
     // resulting ROI into five figures. Those ingredients are priced as *unknown*
     // instead, which nulls the whole creation's cost and keeps it out of the ROI sort
     // rather than letting it top the list on a fabricated number.
+    //
+    // Currency is the exception, and not a small one: coins are flagged untradeable, a
+    // third of all recipes charge a coin fee, and 5 coins really does cost 5gp. Mirrors
+    // `resolveIngredientUnitPrice`, which prices the same rows on the item page.
+    const costIsPriceExpr = {
+        $or: [
+            { $eq: ['$$matched.tradeable_on_ge', true] },
+            { $in: ['$$matched.name', currencyItemNames] },
+        ],
+    };
     const unitPriceExpr = {
         $ifNull: [
             '$$matched.highPrice',
             {
-                $ifNull: [
-                    '$$matched.lowPrice',
-                    { $cond: [{ $eq: ['$$matched.tradeable_on_ge', true] }, '$$matched.cost', null] },
-                ],
+                $ifNull: ['$$matched.lowPrice', { $cond: [costIsPriceExpr, '$$matched.cost', null] }],
             },
         ],
     };
@@ -533,7 +541,9 @@ function buildProfitPipeline(
                 from: 'items',
                 localField: 'consumedIngredientIds',
                 foreignField: '_id',
-                pipeline: [{ $project: { _id: 1, id: 1, highPrice: 1, lowPrice: 1, cost: 1, tradeable_on_ge: 1 } }],
+                pipeline: [
+                    { $project: { _id: 1, id: 1, name: 1, highPrice: 1, lowPrice: 1, cost: 1, tradeable_on_ge: 1 } },
+                ],
                 as: 'ingredientItems',
             },
         },

--- a/src/lib/services/game-item-mongo-service.server.ts
+++ b/src/lib/services/game-item-mongo-service.server.ts
@@ -1,6 +1,6 @@
 import { Types } from 'mongoose';
 import { skillTreeSlugs } from '$lib/constants/skill-tree-pages';
-import { MAX_ITEM_TREE_DEPTH } from '$lib/constants/item-tree';
+import { MAX_ITEM_TREE_DEPTH, MAX_ITEM_TREE_NODES } from '$lib/constants/item-tree';
 import { OsrsboxItemModel, type OsrsboxItemDocument } from '$lib/models/mongo-schemas/osrsbox-db-item-schema';
 import type { IOsrsboxItemWithMeta } from '$lib/models/osrsbox-db-item';
 import { currencyItemNames } from '$lib/helpers/ingredient-price';
@@ -65,9 +65,36 @@ export async function populateIngredientsTree(itemId: string): Promise<IOsrsboxI
         }
     }
 
-    attachIngredientsFromCache(root, root, cache, 0);
+    attachIngredientsFromCache(root, root, cache, 0, new Set([root._id.toString()]), { attached: 0 });
 
     return root;
+}
+
+/**
+ * Rewrites a cloned document's ingredient references as plain hex id strings.
+ *
+ * `structuredClone` strips the ObjectId prototype, so a reference left untouched
+ * serializes as a byte map — `{"buffer":{"0":105,...}}` — which is both ~200 bytes and
+ * unreadable by the chart's lazy loader. The ids are read from `source`, which still holds
+ * real ObjectIds.
+ * @param target - The cloned document to fix up.
+ * @param source - The cached document the clone was made from.
+ */
+function writeIngredientIdsAsStrings(target: IOsrsboxItemWithMeta, source: IOsrsboxItemWithMeta): void {
+    const targetSpecs = target.creationSpecs ?? [];
+    const sourceSpecs = source.creationSpecs ?? [];
+
+    for (let specIndex = 0; specIndex < sourceSpecs.length; specIndex += 1) {
+        const sourceIngredients = sourceSpecs[specIndex]?.ingredients ?? [];
+        const targetIngredients = targetSpecs[specIndex]?.ingredients ?? [];
+
+        for (let i = 0; i < sourceIngredients.length; i += 1) {
+            const raw = sourceIngredients[i]?.item as unknown;
+            const targetIngredient = targetIngredients[i];
+            if (!(raw instanceof Types.ObjectId) || !targetIngredient) continue;
+            targetIngredient.item = raw.toString() as unknown as (typeof targetIngredient)['item'];
+        }
+    }
 }
 
 /**
@@ -88,17 +115,28 @@ function collectIngredientIds(item: IOsrsboxItemWithMeta): string[] {
  * Replaces ingredient ObjectId references with materialized copies of the cached documents.
  * Walks the raw `source` doc for ingredient ids (structuredClone strips the ObjectId prototype
  * from `target`) and gives every occurrence its own clone so the tree has no shared object
- * graphs, which JSON.stringify would otherwise duplicate or treat as circular. The depth
- * budget also bounds cyclic ingredient data.
+ * graphs, which JSON.stringify would otherwise duplicate or treat as circular.
+ *
+ * The depth budget alone does not bound cyclic data. `Plank` lists a `Sawmill voucher` and
+ * the voucher lists planks, so every level of that loop multiplies the node count instead
+ * of adding to it: the twelve-level budget turned `Shaving stand` into hundreds of
+ * thousands of nodes and the request never came back. `ancestors` carries the ids already
+ * open on this path, and an ingredient found there is attached as a leaf rather than
+ * expanded again — the row still renders, the loop just stops unrolling.
+ *
+ * That guard is per-path, so it cannot see a loop that runs through two OSRSBox documents
+ * for the same item — `Black cape` is built from `Blue cape`, which is built from a second
+ * `Black cape` id. `budget` is the backstop for those: once the tree has materialized
+ * `MAX_ITEM_TREE_NODES`, later ingredients are attached with their data but not expanded.
  */
 function attachIngredientsFromCache(
     target: IOsrsboxItemWithMeta,
     source: IOsrsboxItemWithMeta,
     cache: Map<string, IOsrsboxItemWithMeta>,
     depth: number,
+    ancestors: Set<string>,
+    budget: { attached: number },
 ): void {
-    if (depth >= MAX_INGREDIENT_DEPTH) return;
-
     const targetSpecs = target.creationSpecs ?? [];
     const sourceSpecs = source.creationSpecs ?? [];
 
@@ -111,12 +149,33 @@ function attachIngredientsFromCache(
             const targetIngredient = targetIngredients[i];
             if (!(raw instanceof Types.ObjectId) || !targetIngredient) continue;
 
-            const cached = cache.get(raw.toString());
+            const key = raw.toString();
+
+            // Write the plain id first, so an ingredient this walk decides not to expand
+            // still leaves something the client can use. `structuredClone` strips the
+            // ObjectId prototype, and the leftover serializes as a byte-map blob —
+            // {"buffer":{"0":105,...}} — which is ~200 bytes and which the chart's lazy
+            // loader cannot read. The hex string is 26 bytes and it already handles it.
+            targetIngredient.item = key as unknown as (typeof targetIngredient)['item'];
+
+            const cached = cache.get(key);
             if (!cached) continue;
+            if (depth >= MAX_INGREDIENT_DEPTH) continue;
+            if (budget.attached >= MAX_ITEM_TREE_NODES) continue;
 
             const copy = structuredClone(cached);
+            // Do this before the copy is attached: a node reached as a leaf never has its
+            // own ingredients walked, so this is the only chance to replace the prototype
+            // structuredClone just stripped.
+            writeIngredientIdsAsStrings(copy, cached);
             targetIngredient.item = copy as unknown as (typeof targetIngredient)['item'];
-            attachIngredientsFromCache(copy, cached, cache, depth + 1);
+            budget.attached += 1;
+
+            if (ancestors.has(key)) continue;
+
+            ancestors.add(key);
+            attachIngredientsFromCache(copy, cached, cache, depth + 1, ancestors, budget);
+            ancestors.delete(key);
         }
     }
 }
@@ -488,14 +547,26 @@ function buildProfitPipeline(
         },
     };
 
+    // An item that lists itself is not a recipe, it is broken data — a wiki variant panel
+    // read as the item's own, or two OSRSBox documents for one in-game item. Costing it
+    // produces a number, so nothing downstream would notice; this keeps it out of the
+    // profit and ROI sorts the way an unknown price does.
+    const selfReferentialExpr = {
+        $in: ['$_id', { $ifNull: ['$consumedIngredientIds', []] }],
+    };
     const costKnownExpr = {
-        $allElementsTrue: {
-            $map: {
-                input: '$ingredientCostRows',
-                as: 'row',
-                in: { $ne: ['$$row.total', null] },
+        $and: [
+            { $not: '$selfReferential' },
+            {
+                $allElementsTrue: {
+                    $map: {
+                        input: '$ingredientCostRows',
+                        as: 'row',
+                        in: { $ne: ['$$row.total', null] },
+                    },
+                },
             },
-        },
+        ],
     };
     const suppliesSatisfiedExpr = hasSupplies
         ? {
@@ -547,7 +618,7 @@ function buildProfitPipeline(
                 as: 'ingredientItems',
             },
         },
-        { $set: { ingredientCostRows: ingredientCostRowsExpr } },
+        { $set: { ingredientCostRows: ingredientCostRowsExpr, selfReferential: selfReferentialExpr } },
         { $set: { costKnown: costKnownExpr, outputPrice: outputPriceExpr } },
         {
             $set: {

--- a/src/lib/services/game-item-mongo-service.server.ts
+++ b/src/lib/services/game-item-mongo-service.server.ts
@@ -405,7 +405,23 @@ function buildProfitPipeline(
     const neededExpr = hasSupplies
         ? { $max: [0, { $subtract: ['$$amount', '$$supplyQty'] }] }
         : '$$amount';
-    const unitPriceExpr = { $ifNull: ['$$matched.highPrice', { $ifNull: ['$$matched.lowPrice', '$$matched.cost'] }] };
+    // `cost` is the item's base game value, not a market price. Using it for an
+    // ingredient that has no GE market — an untradeable intermediate such as
+    // "Oak seedling (w)", whose cost is 1 — invented a 1gp outlay and sent the
+    // resulting ROI into five figures. Those ingredients are priced as *unknown*
+    // instead, which nulls the whole creation's cost and keeps it out of the ROI sort
+    // rather than letting it top the list on a fabricated number.
+    const unitPriceExpr = {
+        $ifNull: [
+            '$$matched.highPrice',
+            {
+                $ifNull: [
+                    '$$matched.lowPrice',
+                    { $cond: [{ $eq: ['$$matched.tradeable_on_ge', true] }, '$$matched.cost', null] },
+                ],
+            },
+        ],
+    };
     const outputPriceExpr = { $ifNull: ['$highPrice', { $ifNull: ['$lowPrice', '$cost'] }] };
     const ingredientCostRowsExpr = {
         $map: {
@@ -516,7 +532,7 @@ function buildProfitPipeline(
                 from: 'items',
                 localField: 'consumedIngredientIds',
                 foreignField: '_id',
-                pipeline: [{ $project: { _id: 1, id: 1, highPrice: 1, lowPrice: 1, cost: 1 } }],
+                pipeline: [{ $project: { _id: 1, id: 1, highPrice: 1, lowPrice: 1, cost: 1, tradeable_on_ge: 1 } }],
                 as: 'ingredientItems',
             },
         },

--- a/src/lib/services/game-item-profit-pipeline.test.ts
+++ b/src/lib/services/game-item-profit-pipeline.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test';
+import { buildProfitPipeline } from './game-item-mongo-service.server';
+
+/** Every literal in the built pipeline, so a seam can be checked wherever it sits in the tree. */
+function stageText(ironman: boolean): string {
+    return JSON.stringify(buildProfitPipeline(null, false, false, false, ironman, 100));
+}
+
+describe('buildProfitPipeline pricing seams', () => {
+    // The regression this guards: Ironman mode once changed only what the cards displayed, leaving
+    // both sides of the recipe priced from the Grand Exchange. Browse results came back in exactly
+    // the same order in both modes, because the sort keys were computed from untouched GE prices.
+    it('prices the output from the Grand Exchange for a main', () => {
+        expect(stageText(false)).toContain('$highPrice');
+    });
+
+    it('prices the output from alchemy for an Ironman', () => {
+        const ironman = stageText(true);
+        expect(ironman).toContain('$highalch');
+        expect(ironman).toContain('$$matched.highalch');
+    });
+
+    it('does not read a Grand Exchange price anywhere in Ironman mode', () => {
+        const ironman = stageText(true);
+        expect(ironman).not.toContain('$highPrice');
+        expect(ironman).not.toContain('$lowPrice');
+        expect(ironman).not.toContain('$$matched.highPrice');
+        expect(ironman).not.toContain('$$matched.lowPrice');
+    });
+
+    // The ingredient side reads `highalch` off the joined document, so the lookup has to project it.
+    // Without this the ingredient value is always null and every creation cost nulls with it.
+    it('projects highalch on the ingredient lookup', () => {
+        expect(stageText(true)).toContain('"highalch":1');
+    });
+
+    it('subtracts the nature rune price it is given', () => {
+        expect(JSON.stringify(buildProfitPipeline(null, false, false, false, true, 250))).toContain('250');
+    });
+
+    // Coins are money in either mode, and roughly a third of recipes charge a coin fee.
+    it('keeps the currency exception under Ironman', () => {
+        expect(stageText(true)).toContain('Coins');
+    });
+
+    it('still surfaces the realizable value for the card under Ironman only', () => {
+        expect(stageText(true)).toContain('ironmanExitValue');
+        expect(stageText(false)).not.toContain('ironmanExitValue');
+    });
+});

--- a/src/lib/services/game-item-tree.test.ts
+++ b/src/lib/services/game-item-tree.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Integration coverage for the ingredient tree builder.
+ *
+ * Runs against a real MongoDB so the level-by-level fetch and the clone walk are both
+ * exercised. Set TEST_MONGO_URI to point at a throwaway instance:
+ *
+ *   docker run -d --rm -p 27018:27017 mongo:7
+ *   TEST_MONGO_URI=mongodb://127.0.0.1:27018 bun test
+ *
+ * Skipped automatically when no such instance is reachable.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import mongoose from 'mongoose';
+import { MAX_ITEM_TREE_NODES } from '$lib/constants/item-tree';
+
+const TEST_MONGO_URI = process.env.TEST_MONGO_URI ?? 'mongodb://127.0.0.1:27018';
+
+/** Probes for a usable Mongo before declaring the suite. */
+async function mongoReachable(): Promise<boolean> {
+    try {
+        await mongoose.connect(TEST_MONGO_URI, { dbName: 'ge-skiller-tree-test', serverSelectionTimeoutMS: 1500 });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+const reachable = await mongoReachable();
+const describeIfMongo = reachable ? describe : describe.skip;
+
+if (!reachable) {
+    console.warn(`[item-tree] Skipping: no MongoDB at ${TEST_MONGO_URI}`);
+}
+
+describeIfMongo('populateIngredientsTree', () => {
+    let OsrsboxItemModel: typeof import('$lib/models/mongo-schemas/osrsbox-db-item-schema').OsrsboxItemModel;
+    let populateIngredientsTree: typeof import('./game-item-mongo-service.server').populateIngredientsTree;
+
+    const baseItem = {
+        last_updated: '2026-01-01',
+        incomplete: false,
+        members: true,
+        tradeable: true,
+        tradeable_on_ge: true,
+        stackable: false,
+        stacked: null,
+        noted: false,
+        noteable: true,
+        linked_id_item: null,
+        linked_id_noted: null,
+        linked_id_placeholder: null,
+        placeholder: false,
+        equipable: false,
+        equipable_by_player: false,
+        equipable_weapon: false,
+        quest_item: false,
+        duplicate: false,
+        cost: 1,
+        icon: 'x',
+    };
+
+    // Plank and Sawmill voucher list each other, the loop that made the live tree builder
+    // multiply instead of terminate.
+    const plankId = new mongoose.Types.ObjectId();
+    const voucherId = new mongoose.Types.ObjectId();
+    const standId = new mongoose.Types.ObjectId();
+    const logId = new mongoose.Types.ObjectId();
+
+    const spec = (ingredientIds: mongoose.Types.ObjectId[]) => ({
+        experienceGranted: [],
+        requiredSkills: [],
+        ingredients: ingredientIds.map((item) => ({ item, amount: 1, consumedDuringCreation: true })),
+    });
+
+    beforeAll(async () => {
+        ({ OsrsboxItemModel } = await import('$lib/models/mongo-schemas/osrsbox-db-item-schema'));
+        ({ populateIngredientsTree } = await import('./game-item-mongo-service.server'));
+
+        await OsrsboxItemModel.deleteMany({});
+        await OsrsboxItemModel.insertMany([
+            { ...baseItem, _id: logId, id: 1511, name: 'Logs' },
+            { ...baseItem, _id: plankId, id: 960, name: 'Plank', creationSpecs: [spec([logId, voucherId])] },
+            { ...baseItem, _id: voucherId, id: 13357, name: 'Sawmill voucher', creationSpecs: [spec([plankId])] },
+            { ...baseItem, _id: standId, id: 8596, name: 'Shaving stand', creationSpecs: [spec([plankId])] },
+        ]);
+    });
+
+    afterAll(async () => {
+        await OsrsboxItemModel.deleteMany({});
+        await mongoose.disconnect();
+    });
+
+    /** Counts nodes the walk actually materialized, and the ids it left for the client. */
+    function summarize(root: unknown) {
+        let materialized = 0;
+        let references = 0;
+        let badReferences = 0;
+
+        const walk = (item: Record<string, unknown>) => {
+            materialized += 1;
+            const specs = (item?.creationSpecs ?? []) as { ingredients?: { item?: unknown }[] }[];
+            for (const entry of specs) {
+                for (const ingredient of entry.ingredients ?? []) {
+                    const value = ingredient?.item;
+                    if (!value) continue;
+                    if (typeof value === 'object' && (value as { name?: string }).name) {
+                        walk(value as Record<string, unknown>);
+                        continue;
+                    }
+                    references += 1;
+                    // A hex id the client can fetch. An ObjectId that lost its prototype to
+                    // structuredClone serializes as {"buffer":{"0":105,...}} instead.
+                    if (typeof value !== 'string' || !/^[0-9a-f]{24}$/.test(value)) badReferences += 1;
+                }
+            }
+        };
+
+        walk(root as Record<string, unknown>);
+        return { materialized, references, badReferences };
+    }
+
+    it('terminates on a cyclic recipe instead of multiplying', async () => {
+        const tree = await populateIngredientsTree('8596');
+
+        expect(tree).not.toBeNull();
+        const { materialized } = summarize(tree);
+        // Shaving stand -> Plank -> {Logs, Sawmill voucher} -> Plank(leaf). Before the
+        // ancestor guard this ran to hundreds of thousands of nodes and never returned.
+        expect(materialized).toBeLessThanOrEqual(MAX_ITEM_TREE_NODES + 1);
+        expect(materialized).toBeGreaterThan(1);
+    });
+
+    it('leaves an unexpanded ingredient as a readable id', async () => {
+        const tree = await populateIngredientsTree('8596');
+
+        const { references, badReferences } = summarize(tree);
+        expect(references).toBeGreaterThan(0);
+        expect(badReferences).toBe(0);
+    });
+
+    it('still materializes a recipe that has no cycle', async () => {
+        const tree = (await populateIngredientsTree('13357')) as {
+            creationSpecs?: { ingredients?: { item?: { name?: string } }[] }[];
+        } | null;
+
+        expect(tree?.creationSpecs?.[0]?.ingredients?.[0]?.item?.name).toBe('Plank');
+    });
+});

--- a/src/lib/services/game-item-visibility.test.ts
+++ b/src/lib/services/game-item-visibility.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+import { getVisibilityQuery } from './game-item-mongo-service.server';
+
+describe('getVisibilityQuery', () => {
+    // A main has no way to value an item the Grand Exchange won't take, so excluding those keeps
+    // the list free of rows that could only ever render a dash.
+    it('restricts a main to GE-tradeable items with a live price', () => {
+        expect(getVisibilityQuery(false)).toEqual({
+            tradeable_on_ge: true,
+            $or: [{ highPrice: { $gt: 0 } }, { lowPrice: { $gt: 0 } }],
+        });
+    });
+
+    // The same exclusion hides a large share of what an Ironman actually makes, and they never had
+    // the GE price to begin with — alchemy is what values those items for them.
+    it('lifts the tradeable gate for an Ironman and accepts an alchemy value', () => {
+        expect(getVisibilityQuery(true)).toEqual({
+            $or: [{ highPrice: { $gt: 0 } }, { lowPrice: { $gt: 0 } }, { highalch: { $gt: 0 } }],
+        });
+    });
+
+    it('does not constrain tradeability for an Ironman', () => {
+        expect(getVisibilityQuery(true)).not.toHaveProperty('tradeable_on_ge');
+    });
+
+    // Defaulting to the Ironman-relaxed filter would quietly widen every existing caller.
+    it('defaults to the main behaviour', () => {
+        expect(getVisibilityQuery()).toEqual(getVisibilityQuery(false));
+    });
+
+    // An item with neither a price nor an alchemy value still has nothing to show, in either mode.
+    it('always requires at least one usable value', () => {
+        for (const ironman of [false, true]) {
+            const clauses = getVisibilityQuery(ironman).$or as Record<string, unknown>[];
+            expect(clauses.length).toBeGreaterThan(0);
+        }
+    });
+});

--- a/src/lib/stores/character-store.svelte.ts
+++ b/src/lib/stores/character-store.svelte.ts
@@ -1,6 +1,12 @@
 // src/lib/stores/character-store.svelte.ts
 import { LocalStorageStoreNames } from '$lib/constants/enums/local-storage-store-names';
 import type { CharacterProfile } from '$lib/models/player-stats';
+import {
+    DEFAULT_ACCOUNT_TYPE,
+    canUseGrandExchange,
+    normalizeAccountType,
+    type AccountType,
+} from '$lib/models/account-type';
 import { LocalStorage } from '$lib/services/persisted-store.svelte';
 
 interface ICharacterStoreData {
@@ -28,4 +34,25 @@ export function getCharacters() {
 // live proxied active character id.
 export function getActiveCharacter() {
     return _store.current.activeCharacter;
+}
+
+// live proxied account type of the active character.
+// Falls back to the default when no character is selected, so a visitor with no profile keeps
+// seeing Grand Exchange prices exactly as before.
+export function getActiveAccountType(): AccountType {
+    const activeId = _store.current.activeCharacter;
+    if (activeId === undefined || activeId === null) return DEFAULT_ACCOUNT_TYPE;
+
+    const active = _store.current.characters.find((c) => String(c.id) === String(activeId));
+    return normalizeAccountType(active?.accountType);
+}
+
+/** Whether the active character may use the Grand Exchange, i.e. whether GE prices apply to them. */
+export function activeCanUseGrandExchange(): boolean {
+    return canUseGrandExchange(getActiveAccountType());
+}
+
+/** Whether the active character should be shown Ironman pricing. */
+export function activeIsIronman(): boolean {
+    return !activeCanUseGrandExchange();
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -30,7 +30,6 @@
     });
 </script>
 
-
 <svelte:head>
     <title>{shareTitle}</title>
     <meta name="description" content={shareDescription} />

--- a/src/routes/api/game-items/+server.ts
+++ b/src/routes/api/game-items/+server.ts
@@ -30,6 +30,7 @@ export const GET: RequestHandler = async ({ url }) => {
     let supplies: PlayerSupplies | undefined;
     const suppliesActive = url.searchParams.get('suppliesActive') === '1';
     const profitMode = url.searchParams.get('profitMode') === '1';
+    const ironman = url.searchParams.get('ironman') === '1';
 
     if (skillLevelsParam) {
         try {
@@ -70,6 +71,7 @@ export const GET: RequestHandler = async ({ url }) => {
         supplies,
         suppliesActive,
         profitMode,
+        ironman,
     });
     return new Response(JSON.stringify(paginated));
 };

--- a/src/routes/api/search-items/+server.ts
+++ b/src/routes/api/search-items/+server.ts
@@ -4,7 +4,8 @@ import { searchGameItems } from '$lib/services/game-item-mongo-service.server';
 export const GET: RequestHandler = async ({ url }) => {
     const q = url.searchParams.get('q') ?? '';
     const limit = Number(url.searchParams.get('limit')) || 10;
+    const ironman = url.searchParams.get('ironman') === '1';
 
-    const results = await searchGameItems(q, limit);
+    const results = await searchGameItems(q, limit, ironman);
     return new Response(JSON.stringify(results));
 };

--- a/src/routes/items/[id=integer]/+page.svelte
+++ b/src/routes/items/[id=integer]/+page.svelte
@@ -22,10 +22,20 @@
         getSuppliesForCharacter,
         updateSuppliesForCharacter,
     } from '$lib/stores/bank-items-store';
-    import { getStoreRoot } from '$lib/stores/character-store.svelte';
+    import { getStoreRoot, getActiveAccountType } from '$lib/stores/character-store.svelte';
+    import { canUseGrandExchange } from '$lib/models/account-type';
+    import { NATURE_RUNE_FALLBACK_PRICE, alchemyValueAfterRune } from '$lib/constants/alchemy';
     import { toast } from 'svelte-sonner';
 
-    const { data }: { data: { gameItem: IOsrsboxItemWithMeta | null; showDevControls?: boolean } } = $props();
+    const {
+        data,
+    }: {
+        data: {
+            gameItem: IOsrsboxItemWithMeta | null;
+            natureRunePrice?: number | null;
+            showDevControls?: boolean;
+        };
+    } = $props();
 
     let loading = $state(false);
     let gameItem = $state<IOsrsboxItemWithMeta | null>(data.gameItem ?? null);
@@ -68,6 +78,34 @@
         const price = normalizePrice(gameItem?.lowPrice);
         if (alch === null || alch === undefined || price === null) return null;
         return alch - price;
+    });
+
+    // Which prices apply to the reader. Everything below branches on this one boolean rather than on
+    // the account type, so the four Ironman variants cannot drift apart.
+    const usesGrandExchange = $derived(canUseGrandExchange(getActiveAccountType()));
+    const natureRunePrice = $derived(normalizePrice(data.natureRunePrice) ?? NATURE_RUNE_FALLBACK_PRICE);
+
+    // What an Ironman actually clears by alching, rather than the alch-versus-market-price figure
+    // above. They never bought the item at a market price, so subtracting one tells them nothing.
+    const highAlchValue = $derived(() => alchemyValueAfterRune(gameItem?.highalch, natureRunePrice));
+    const lowAlchValue = $derived(() => alchemyValueAfterRune(gameItem?.lowalch, natureRunePrice));
+
+    const isTradeableOnGe = $derived(gameItem?.tradeable_on_ge !== false);
+    const hasLivePrice = $derived(
+        normalizePrice(gameItem?.highPrice) !== null || normalizePrice(gameItem?.lowPrice) !== null,
+    );
+    // The Grand Exchange card is meaningless for an item that cannot be listed there, and merely
+    // deprioritised for an Ironman looking at one that can — it is still real information, just not
+    // the number they act on.
+    const showGrandExchangeCard = $derived(isTradeableOnGe);
+    const collapseGrandExchangeCard = $derived(isTradeableOnGe && !usesGrandExchange);
+    let grandExchangeOpen = $state(false);
+
+    // Why a price is missing, so a bare dash never reads as broken data.
+    const missingPriceReason = $derived.by(() => {
+        if (hasLivePrice) return null;
+        if (!isTradeableOnGe) return 'Not tradeable';
+        return 'No recent trades';
     });
     const devControlsEnabled = Boolean(data.showDevControls);
 
@@ -305,9 +343,7 @@
         if (!ensureActiveCharacter()) return;
         const itemId = Number(gameItem?.id);
         if (!Number.isFinite(itemId) || !gameItem) return;
-        updateSuppliesForCharacter(activeCharacterId, (items) =>
-            items.filter((entry) => Number(entry.id) !== itemId),
-        );
+        updateSuppliesForCharacter(activeCharacterId, (items) => items.filter((entry) => Number(entry.id) !== itemId));
         toast.success(`Removed ${gameItem.name} from your supplies.`);
         bankDialogOpen = false;
     }
@@ -495,56 +531,75 @@
             <Skeleton class="h-44 w-full" />
             <Skeleton class="h-44 w-full" />
         {:else}
-            <section class="border rounded-lg bg-card shadow-sm overflow-hidden">
-                <div class="flex items-center justify-between p-4 border-b">
-                    <h3 class="text-lg font-semibold">Grand Exchange</h3>
-                </div>
-                <Table.Root>
-                    <Table.Body>
-                        <Table.Row>
-                            <Table.Cell class="font-medium">
-                                <div class="flex items-center gap-2">
-                                    <span
-                                        class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted border item-card__img-background shadow-sm"
+            {#if showGrandExchangeCard}
+                <section
+                    class="border rounded-lg bg-card shadow-sm overflow-hidden {collapseGrandExchangeCard
+                        ? 'lg:order-last opacity-80'
+                        : ''}"
+                >
+                    <div class="flex items-center justify-between p-4 border-b">
+                        <h3 class="text-lg font-semibold">Grand Exchange</h3>
+                        {#if collapseGrandExchangeCard}
+                            <Button variant="ghost" size="sm" onclick={() => (grandExchangeOpen = !grandExchangeOpen)}>
+                                {grandExchangeOpen ? 'Hide' : 'Show'} Grand Exchange prices
+                            </Button>
+                        {/if}
+                    </div>
+                    {#if !collapseGrandExchangeCard || grandExchangeOpen}
+                        <Table.Root>
+                            <Table.Body>
+                                <Table.Row>
+                                    <Table.Cell class="font-medium">
+                                        <div class="flex items-center gap-2">
+                                            <span
+                                                class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted border item-card__img-background shadow-sm"
+                                            >
+                                                <TrendingUp class="h-4 w-4" />
+                                            </span>
+                                            <span>High price</span>
+                                        </div>
+                                    </Table.Cell>
+                                    <Table.Cell class="text-end">
+                                        {#if missingPriceReason}
+                                            <span class="text-muted-foreground">{missingPriceReason}</span>
+                                        {:else}
+                                            {formatPrice(gameItem?.highPrice)}
+                                        {/if}
+                                    </Table.Cell>
+                                </Table.Row>
+                                <Table.Row>
+                                    <Table.Cell class="font-medium">
+                                        <div class="flex items-center gap-2">
+                                            <span
+                                                class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted border item-card__img-background shadow-sm"
+                                            >
+                                                <TrendingDown class="h-4 w-4" />
+                                            </span>
+                                            <span>Low price</span>
+                                        </div>
+                                    </Table.Cell>
+                                    <Table.Cell class="text-end">{formatPrice(gameItem?.lowPrice)}</Table.Cell>
+                                </Table.Row>
+                                <Table.Row>
+                                    <Table.Cell class="font-medium">
+                                        <div class="flex items-center gap-2">
+                                            <span
+                                                class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted border item-card__img-background shadow-sm"
+                                            >
+                                                <Package class="h-4 w-4" />
+                                            </span>
+                                            <span>Buy limit</span>
+                                        </div>
+                                    </Table.Cell>
+                                    <Table.Cell class="text-end"
+                                        >{formatValue(gameItem?.buyLimit ?? gameItem?.buy_limit, '')}</Table.Cell
                                     >
-                                        <TrendingUp class="h-4 w-4" />
-                                    </span>
-                                    <span>High price</span>
-                                </div>
-                            </Table.Cell>
-                            <Table.Cell class="text-end">{formatPrice(gameItem?.highPrice)}</Table.Cell>
-                        </Table.Row>
-                        <Table.Row>
-                            <Table.Cell class="font-medium">
-                                <div class="flex items-center gap-2">
-                                    <span
-                                        class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted border item-card__img-background shadow-sm"
-                                    >
-                                        <TrendingDown class="h-4 w-4" />
-                                    </span>
-                                    <span>Low price</span>
-                                </div>
-                            </Table.Cell>
-                            <Table.Cell class="text-end">{formatPrice(gameItem?.lowPrice)}</Table.Cell>
-                        </Table.Row>
-                        <Table.Row>
-                            <Table.Cell class="font-medium">
-                                <div class="flex items-center gap-2">
-                                    <span
-                                        class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted border item-card__img-background shadow-sm"
-                                    >
-                                        <Package class="h-4 w-4" />
-                                    </span>
-                                    <span>Buy limit</span>
-                                </div>
-                            </Table.Cell>
-                            <Table.Cell class="text-end"
-                                >{formatValue(gameItem?.buyLimit ?? gameItem?.buy_limit, '')}</Table.Cell
-                            >
-                        </Table.Row>
-                    </Table.Body>
-                </Table.Root>
-            </section>
+                                </Table.Row>
+                            </Table.Body>
+                        </Table.Root>
+                    {/if}
+                </section>
+            {/if}
 
             <section class="border rounded-lg bg-card shadow-sm overflow-hidden">
                 <div class="flex items-center justify-between p-4 border-b">
@@ -598,7 +653,7 @@
                                             class="h-4 w-4 drop-shadow"
                                         />
                                     </span>
-                                    <span>Store price</span>
+                                    <span>Value</span>
                                 </div>
                             </Table.Cell>
                             <Table.Cell class="text-end">{formatValue(gameItem?.cost)}</Table.Cell>
@@ -617,18 +672,35 @@
             </div>
             <Table.Root>
                 <Table.Body>
+                    {#if usesGrandExchange}
+                        <Table.Row>
+                            <Table.Cell class="font-medium">
+                                <div class="flex items-center gap-2">
+                                    <span
+                                        class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted border item-card__img-background shadow-sm"
+                                    >
+                                        <ArrowLeftRight class="h-4 w-4" />
+                                    </span>
+                                    <span>GE spread</span>
+                                </div>
+                            </Table.Cell>
+                            <Table.Cell class="text-end">{formatDelta(geSpread())}</Table.Cell>
+                        </Table.Row>
+                    {/if}
                     <Table.Row>
                         <Table.Cell class="font-medium">
                             <div class="flex items-center gap-2">
                                 <span
                                     class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted border item-card__img-background shadow-sm"
                                 >
-                                    <ArrowLeftRight class="h-4 w-4" />
+                                    <Coins class="h-4 w-4" />
                                 </span>
-                                <span>GE spread</span>
+                                <span>{usesGrandExchange ? 'High alch profit' : 'High alch value'}</span>
                             </div>
                         </Table.Cell>
-                        <Table.Cell class="text-end">{formatDelta(geSpread())}</Table.Cell>
+                        <Table.Cell class="text-end">
+                            {usesGrandExchange ? formatDelta(highAlchProfit()) : formatValue(highAlchValue())}
+                        </Table.Cell>
                     </Table.Row>
                     <Table.Row>
                         <Table.Cell class="font-medium">
@@ -638,23 +710,12 @@
                                 >
                                     <Coins class="h-4 w-4" />
                                 </span>
-                                <span>High alch profit</span>
+                                <span>{usesGrandExchange ? 'Low alch profit' : 'Low alch value'}</span>
                             </div>
                         </Table.Cell>
-                        <Table.Cell class="text-end">{formatDelta(highAlchProfit())}</Table.Cell>
-                    </Table.Row>
-                    <Table.Row>
-                        <Table.Cell class="font-medium">
-                            <div class="flex items-center gap-2">
-                                <span
-                                    class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted border item-card__img-background shadow-sm"
-                                >
-                                    <Coins class="h-4 w-4" />
-                                </span>
-                                <span>Low alch profit</span>
-                            </div>
+                        <Table.Cell class="text-end">
+                            {usesGrandExchange ? formatDelta(lowAlchProfit()) : formatValue(lowAlchValue())}
                         </Table.Cell>
-                        <Table.Cell class="text-end">{formatDelta(lowAlchProfit())}</Table.Cell>
                     </Table.Row>
                 </Table.Body>
             </Table.Root>

--- a/src/routes/items/[id=integer]/+page.svelte
+++ b/src/routes/items/[id=integer]/+page.svelte
@@ -37,7 +37,17 @@
     const treeCacheTtlMs = 5 * 60 * 1000;
     const iconSrc = $derived(iconToDataUri(gameItem?.icon));
     const wikiUrl = $derived(() => {
-        const slug = gameItem?.wiki_name ?? gameItem?.name ?? gameItem?.wikiName;
+        // The stored URL is authoritative and already carries the version anchor, so an
+        // item from a switch-infobox page ("Oak seedling (w)") lands on its own section.
+        // Building the link from `wiki_name` instead 404s for those, because OSRSBox
+        // synthesises that field as "<page title> (<version>)" — see
+        // scripts/WIKI-NAME-NORMALIZATION.md.
+        const storedUrl = gameItem?.wiki_url?.trim();
+        if (storedUrl) return storedUrl;
+
+        // No stored URL: fall back to the derived page title, then the in-game name.
+        // `wiki_name` stays last for the same reason it cannot be trusted above.
+        const slug = gameItem?.wiki_page_title ?? gameItem?.name ?? gameItem?.wiki_name ?? gameItem?.wikiName;
         if (!slug) return null;
         return `https://oldschool.runescape.wiki/w/${encodeURIComponent(slug.replaceAll(' ', '_'))}`;
     });

--- a/src/routes/items/[id=integer]/+page.ts
+++ b/src/routes/items/[id=integer]/+page.ts
@@ -1,12 +1,23 @@
+import { NATURE_RUNE_ITEM_ID } from '$lib/constants/alchemy';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ fetch, params }) => {
-    const response = await fetch(`/api/game-item?id=${params.id}`);
+    // The nature rune's price is fetched alongside the item because every alchemy figure shown to an
+    // Ironman is net of the rune the cast burns. Reading it live beats a hardcoded gp figure, which
+    // would go stale the moment the market moves.
+    const [response, natureRuneResponse] = await Promise.all([
+        fetch(`/api/game-item?id=${params.id}`),
+        fetch(`/api/game-item?id=${NATURE_RUNE_ITEM_ID}`),
+    ]);
+
+    // A failed nature rune lookup is not worth failing the page over; the alchemy helper falls back
+    // to a documented default so the number is slightly stale rather than absent.
+    const natureRunePrice = natureRuneResponse.ok ? ((await natureRuneResponse.json())?.highPrice ?? null) : null;
 
     if (!response.ok) {
-        return { gameItem: null };
+        return { gameItem: null, natureRunePrice };
     }
 
     const gameItem = await response.json();
-    return { gameItem };
+    return { gameItem, natureRunePrice };
 };

--- a/src/routes/my-character/+page.svelte
+++ b/src/routes/my-character/+page.svelte
@@ -12,7 +12,9 @@
     import SkillsGrid from '$lib/components/global/skills-grid.svelte';
     import { iconToDataUri } from '$lib/helpers/icon-to-data-uri';
     import { resolve } from '$app/paths';
+    import AccountTypeSelect from '$lib/components/global/account-type-select.svelte';
     import { CharacterProfile, type ICharacterProfile } from '$lib/models/player-stats';
+    import type { AccountType } from '$lib/models/account-type';
     import type { IGameItem } from '$lib/models/game-item';
     import { getStoreRoot } from '$lib/stores/character-store.svelte';
     import {
@@ -48,11 +50,13 @@
         name = '',
         skillLevels: ICharacterProfile['skillLevels'] = defaultSkillLevels,
         id?: ICharacterProfile['id'],
+        accountType?: ICharacterProfile['accountType'],
     ): ICharacterProfile => {
-        const profile = new CharacterProfile(name, { ...skillLevels }, id);
+        const profile = new CharacterProfile(name, { ...skillLevels }, id, accountType);
         return {
             id: profile.id,
             name: profile.name,
+            accountType: profile.accountType,
             skillLevels: { ...profile.skillLevels },
         };
     };
@@ -94,7 +98,12 @@
 
     $effect(() => {
         if (activeCharacter) {
-            draft = createDraft(activeCharacter.name, { ...activeCharacter.skillLevels }, activeCharacter.id);
+            draft = createDraft(
+                activeCharacter.name,
+                { ...activeCharacter.skillLevels },
+                activeCharacter.id,
+                activeCharacter.accountType,
+            );
             return;
         }
 
@@ -226,6 +235,7 @@
         const updated = {
             ...draft,
             name: trimmedName,
+            accountType: draft.accountType,
             skillLevels: { ...draft.skillLevels },
         };
         const existingIndex = next.findIndex((character) => character.id === updated.id);
@@ -246,7 +256,7 @@
 
         try {
             const imported = await fetchCharacterDetailsFromWOM(trimmedName);
-            draft = createDraft(trimmedName, { ...imported.skillLevels }, draft.id);
+            draft = createDraft(trimmedName, { ...imported.skillLevels }, draft.id, draft.accountType);
             toast.success(`Imported skill levels for "${trimmedName}".`);
         } catch (error) {
             console.error(error);
@@ -254,6 +264,10 @@
         } finally {
             importLoading = false;
         }
+    }
+
+    function handleAccountTypeChange(next: AccountType) {
+        draft.accountType = next;
     }
 
     function handleSkillChange(skill: keyof ICharacterProfile['skillLevels'], value: number) {
@@ -334,18 +348,14 @@
         if (!ensureActiveCharacter()) return;
         const id = Number(itemId);
         if (!Number.isFinite(id)) return;
-        updateSuppliesForCharacter(activeCharacterId, (items) =>
-            items.filter((entry) => Number(entry.id) !== id),
-        );
+        updateSuppliesForCharacter(activeCharacterId, (items) => items.filter((entry) => Number(entry.id) !== id));
     }
 </script>
 
 <div class="content-sizing pt-6 pb-10 space-y-8">
     <header class="space-y-2">
         <h1 class="text-3xl font-bold">My character</h1>
-        <p class="text-muted-foreground">
-            Update your skill levels and supplies.
-        </p>
+        <p class="text-muted-foreground">Update your skill levels and supplies.</p>
     </header>
 
     <Accordion.Root type="multiple" class="rounded-lg border" value={['supplies']}>
@@ -365,14 +375,14 @@
                     <form class="space-y-6" onsubmit={saveCharacter}>
                         <div>
                             <Label class="capitalize text-xs" for="my-character-name">Character name</Label>
-                            <Input
-                                id="my-character-name"
-                                type="text"
-                                required
-                                aria-required
-                                bind:value={draft.name}
-                            />
+                            <Input id="my-character-name" type="text" required aria-required bind:value={draft.name} />
                         </div>
+
+                        <AccountTypeSelect
+                            value={draft.accountType}
+                            onChange={handleAccountTypeChange}
+                            idPrefix="my-character"
+                        />
 
                         <SkillsGrid
                             skillLevels={draft.skillLevels}
@@ -415,9 +425,7 @@
             <Accordion.Content class="px-6">
                 <div class="space-y-4 pt-2">
                     <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                        <p class="text-sm text-muted-foreground">
-                            Add items to your supplies.
-                        </p>
+                        <p class="text-sm text-muted-foreground">Add items to your supplies.</p>
                         <Button
                             onclick={openSuppliesDialog}
                             aria-disabled={!hasActiveCharacter}
@@ -538,7 +546,9 @@
                             {#each searchResults as item (item.id)}
                                 <Command.Item value={item.name} class="!cursor-default">
                                     <div class="flex w-full items-center gap-3">
-                                        <span class="inline-flex h-9 w-9 items-center justify-center rounded bg-muted border">
+                                        <span
+                                            class="inline-flex h-9 w-9 items-center justify-center rounded bg-muted border"
+                                        >
                                             {#if item.icon}
                                                 <img
                                                     src={iconToDataUri(item.icon)}


### PR DESCRIPTION
Ironman support: the two planning docs, then the first slice of the implementation.

> [!IMPORTANT]
> **This branch has PR #16 merged into it.** Merging this PR merges #16's work as well (27 files, wiki page titles, variant recipes, bounded ingredient tree). That was deliberate — the Ironman pricing builds directly on `ingredient-price.ts`, which #16 introduced. Worth deciding whether #16 lands on its own first.

## Planning docs

- **`docs/ironman-feature-recommendations.md`** — a scan of the data model, services and UI against what Ironman accounts need, with specs for the four requested features plus five more.
- **`docs/ironman-ui-plan.md`** — where the mode lives, what changes on each screen, and the exact copy for each string.

## Implementation (build-order steps 1–4)

**Account type on the character profile.** `account-type.ts` holds the enum, the option copy, and the `canUseGrandExchange` predicate every pricing decision branches on, so the four Ironman variants cannot drift apart. Missing and unrecognised values normalize to `main`, so profiles saved before this field keep today's behaviour. Selector in both edit surfaces; badge in the character switcher.

Two save paths would have silently dropped the new field: the dialog's update branch copied only `skillLevels` onto the existing character, and a Wise Old Man import rebuilt the draft from scratch. WOM reports levels, not game mode. Both fixed.

**Both sides of a recipe are priced from Ironman values.** `buildProfitPipeline` priced ingredients *and* output from GE prices in either mode, so `creationCost` / `creationProfit` / `creationRoi` — the sort keys — came out identical and the browse ranking did not change at all. Both seams now swap to alchemy net of the nature rune, mirrored between `resolveIronmanUnitValue` and the aggregation so the browse list, item page and cost table agree. The ingredient `$lookup` projects `highalch`; without it the ingredient side reads null and every creation cost nulls with it.

Items nothing can value stay `null` rather than becoming `0` — unknown and worthless are different claims, and shop prices may yet value them. Nulling drops them from the ROI sort instead of ranking them on an invented number, the same treatment #16 gives an unpriceable ingredient. Currency keeps its `cost` exception.

**Untradeables reach browse and search.** `getVisibilityQuery()` lifts the `tradeable_on_ge` gate under Ironman and accepts `highalch` as a value. The value sort gains `highalch` as a key — every key is a stored field, so it stays index-eligible rather than becoming a computed sort.

**Item page and cards.** "Store price" → "Value" (`cost` is the base value; a general store neither buys nor sells at it). Alch rows become alch *value* net of the rune under Ironman — the existing "alch profit" is alch minus GE price, a merchant's flip metric meaningless to someone who never bought at market. GE spread hidden. The GE card is dropped for untradeables and collapsed behind a plain disclosure for a tradeable one, with no disclaimer. Cards show the realizable value with a `High alch` source line instead of a price the reader can never get, and drop the hourly timestamp.

**No-price states** say why — "Not tradeable", "No recent trades", "No sell value" — rather than a bare dash that reads as broken data.

## What is not here

Steps 5–8 need shop data that does not exist yet: the Shops card, the sell-to-shop break-even block, shop-value sorting, and folding shop prices into the value basis. `scripts/populate-shops.ts` is the gate. Ironman mode today values via alchemy only, so expect the Ironman list to be **shorter** than the main list — items whose ingredients have no alchemy value correctly null out. That shrinks once shop data lands.

## Verification

`svelte-check` holds at the same 34 pre-existing errors as the merge base and `eslint` at the same 4 — both confirmed by stashing. 83 tests pass, including a structural test asserting no Grand Exchange price appears anywhere in the Ironman pipeline, which fails against the commit before the fix. Production build succeeds locally.

The two MongoDB-backed suites still skip — no Mongo reachable in this environment, same limitation #16 noted.

## Open questions

- Where nature rune cost should live. It is currently read live from the database and cached, with a documented fallback; a character-profile field was the suggestion.
- Whether "sell value" is the right wording for the Ironman value sort label.
- Whether UIM/GIM account-type copy should read identically to plain Ironman, or keep their `No bank.` / `Trading is limited to your group.` trailing clauses.
